### PR TITLE
update rich text block types

### DIFF
--- a/src/block-kit/block-elements.ts
+++ b/src/block-kit/block-elements.ts
@@ -42,13 +42,13 @@ export type AnyActionBlockElementType =
   | "file_input";
 
 export interface BlockElement<
-  T extends AnyBlockElementType = AnyBlockElementType,
+  T extends AnyBlockElementType = AnyBlockElementType
 > {
   type: T;
 }
 
 export interface ActionBlockElement<
-  T extends AnyActionBlockElementType = AnyActionBlockElementType,
+  T extends AnyActionBlockElementType = AnyActionBlockElementType
 > extends BlockElement<T> {
   type: T;
   action_id?: string;
@@ -355,30 +355,30 @@ export interface FileInput extends ActionBlockElement<"file_input"> {
 
 // https://api.slack.com/changelog/2019-09-what-they-see-is-what-you-get-and-more-and-less
 
-export type RichTextBlockElement = BlockElement<
+export type RichTextBlockSubElement = BlockElement<
   | "rich_text_list"
   | "rich_text_preformatted"
   | "rich_text_quote"
   | "rich_text_section"
 >;
 
-export interface RichTextList extends RichTextBlockElement {
+export interface RichTextList extends RichTextBlockSubElement {
   type: "rich_text_list";
   style?: "bullet" | "ordered";
   indent?: number;
   offset?: number;
   border?: number;
-  elements: RichTextBlockElement[];
+  elements: RichTextBlockSubElement[];
 }
-export interface RichTextPreformatted extends RichTextBlockElement {
+export interface RichTextPreformatted extends RichTextBlockSubElement {
   type: "rich_text_preformatted";
-  elements: RichTextBlockElement[];
+  elements: RichTextSectionElement[];
 }
-export interface RichTextQuote extends RichTextBlockElement {
+export interface RichTextQuote extends RichTextBlockSubElement {
   type: "rich_text_quote";
-  elements: RichTextBlockElement[];
+  elements: RichTextSectionElement[];
 }
-export interface RichTextSection extends RichTextBlockElement {
+export interface RichTextSection extends RichTextBlockSubElement {
   type: "rich_text_section";
   elements: AnyRichTextSectionElement[];
 }

--- a/src_deno/block-kit/block-elements.ts
+++ b/src_deno/block-kit/block-elements.ts
@@ -366,30 +366,30 @@ export interface FileInput extends ActionBlockElement<"file_input"> {
 
 // https://api.slack.com/changelog/2019-09-what-they-see-is-what-you-get-and-more-and-less
 
-export type RichTextBlockElement = BlockElement<
+export type RichTextBlockSubElement = BlockElement<
   | "rich_text_list"
   | "rich_text_preformatted"
   | "rich_text_quote"
   | "rich_text_section"
 >;
 
-export interface RichTextList extends RichTextBlockElement {
+export interface RichTextList extends RichTextBlockSubElement {
   type: "rich_text_list";
   style?: "bullet" | "ordered";
   indent?: number;
   offset?: number;
   border?: number;
-  elements: RichTextBlockElement[];
+  elements: RichTextBlockSubElement[];
 }
-export interface RichTextPreformatted extends RichTextBlockElement {
+export interface RichTextPreformatted extends RichTextBlockSubElement {
   type: "rich_text_preformatted";
-  elements: RichTextBlockElement[];
+  elements: RichTextSectionElement[];
 }
-export interface RichTextQuote extends RichTextBlockElement {
+export interface RichTextQuote extends RichTextBlockSubElement {
   type: "rich_text_quote";
-  elements: RichTextBlockElement[];
+  elements: RichTextSectionElement[];
 }
-export interface RichTextSection extends RichTextBlockElement {
+export interface RichTextSection extends RichTextBlockSubElement {
   type: "rich_text_section";
   elements: AnyRichTextSectionElement[];
 }


### PR DESCRIPTION
# Changes

1.  **Suggested rename**: `RichTextBlockElement` --> `RichTextBlockSubElement`

To be consistent with the following in the API docs:

> Sub-elements are what comprise the elements array in a rich text block. There are four available rich text object sub-elements.: rich_text_section, rich_text_list, rich_text_preformatted, and rich_text_quote.

2. Fix type for `elements` array for `RichTextPreformatted` and `RichTextQuote`.

> elements | Object [] | An array of rich text elements, which can include the following types: channel, emoji, link, text, user, and user_group.
([source](https://api.slack.com/reference/block-kit/blocks#rich_text_preformatted))