### PR TITLE
Add rich text date element field types

### DIFF
--- a/src/block-kit/block-elements.ts
+++ b/src/block-kit/block-elements.ts
@@ -351,6 +351,8 @@ export interface RichTextSectionDate extends RichTextSectionElement {
   timestamp: number;
   format: string;
   style?: RichTextSectionElementStyleWithCode;
+  url?: string;
+  fallback?: string;
 }
 export interface RichTextSectionBroadcast extends RichTextSectionElement {
   type: "broadcast";

--- a/src_deno/block-kit/block-elements.ts
+++ b/src_deno/block-kit/block-elements.ts
@@ -467,6 +467,8 @@ export interface RichTextSectionDate extends RichTextSectionElement {
   timestamp: number;
   format: string;
   style?: RichTextSectionElementStyleWithCode;
+  url?: string;
+  fallback?: string;
 }
 export interface RichTextSectionBroadcast extends RichTextSectionElement {
   type: "broadcast";


### PR DESCRIPTION
Adds `url` and `fallback` field types to the rich text `date` element.
See `date` in documentation: https://api.slack.com/reference/block-kit/blocks#element-types