### PR TITLE
Update rich_text_list elements type

### DIFF
--- a/src/block-kit/block-elements.ts
+++ b/src/block-kit/block-elements.ts
@@ -277,7 +277,7 @@ export interface RichTextList extends RichTextBlockSubElement {
   indent?: number;
   offset?: number;
   border?: number;
-  elements: AnyRichTextBlockElement[];
+  elements: RichTextSection[];
 }
 export interface RichTextPreformatted extends RichTextBlockSubElement {
   type: "rich_text_preformatted";

--- a/src_deno/block-kit/block-elements.ts
+++ b/src_deno/block-kit/block-elements.ts
@@ -379,7 +379,7 @@ export interface RichTextList extends RichTextBlockSubElement {
   indent?: number;
   offset?: number;
   border?: number;
-  elements: AnyRichTextBlockElement[];
+  elements: RichTextSection[];
 }
 export interface RichTextPreformatted extends RichTextBlockSubElement {
   type: "rich_text_preformatted";


### PR DESCRIPTION
The `rich_text_list` is the only rich text block sub-element whose elements themselves can be other nested rich text sub-elements:
> An array of [rich_text_section](https://api.slack.com/reference/block-kit/blocks#rich_text_section) objects

https://api.slack.com/reference/block-kit/blocks#rich_text_list