### PR TITLE
make rich_text_link text optional

### DIFF
--- a/src/block-kit/block-elements.ts
+++ b/src/block-kit/block-elements.ts
@@ -334,7 +334,7 @@ export interface RichTextSectionEmoji extends RichTextSectionElement {
 export interface RichTextSectionLink extends RichTextSectionElement {
   type: "link";
   url: string;
-  text: string;
+  text?: string;
   unsafe?: boolean;
   style?: RichTextSectionElementStyleWithCode;
 }

--- a/src_deno/block-kit/block-elements.ts
+++ b/src_deno/block-kit/block-elements.ts
@@ -450,7 +450,7 @@ export interface RichTextSectionEmoji extends RichTextSectionElement {
 export interface RichTextSectionLink extends RichTextSectionElement {
   type: "link";
   url: string;
-  text: string;
+  text?: string;
   unsafe?: boolean;
   style?: RichTextSectionElementStyleWithCode;
 }


### PR DESCRIPTION
The `text` property for the `link` rich text section element is optional. When excluded, the URL is also used as the inner text.

Ref: https://api.slack.com/reference/block-kit/blocks#link-element-type