### PR TITLE
version 1.1.11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,4 @@ tmp/
 .env
 .vscode/
 .idea/
+.context/

--- a/.npmignore
+++ b/.npmignore
@@ -12,3 +12,4 @@ vite.config.ts
 .vscode/
 vite.config.mjs
 coverage/
+.context/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "slack-web-api-client",
-  "version": "1.1.9",
+  "version": "1.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "slack-web-api-client",
-      "version": "1.1.9",
+      "version": "1.1.11",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^2.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slack-web-api-client",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "Streamlined Slack Web API client for TypeScript",
   "main": "dist/index.js",
   "scripts": {

--- a/src_deno/deno.json
+++ b/src_deno/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@seratch/slack-web-api-client",
-  "version": "1.1.9",
+  "version": "1.1.11",
   "exports": "./mod.ts",
   "lint": {
     "rules": {


### PR DESCRIPTION
## Summary
- Bump version to 1.1.11 across package.json, package-lock.json, and deno.json
- Add `.context/` to `.gitignore` and `.npmignore` to exclude Conductor workspace files from git and npm publishes
- Fixes 1.1.10 which was published with extraneous `.context` files

## Test plan
- [ ] Verify `npm pack` output does not include `.context` files
- [ ] Publish 1.1.11 to npm after merge
- [ ] Deprecate 1.1.10 on npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)