### PR TITLE
Add underline to RichTextSectionElementStyle

### DIFF
--- a/src/block-kit/block-elements.ts
+++ b/src/block-kit/block-elements.ts
@@ -386,6 +386,7 @@ export interface RichTextSectionElementStyle {
   bold?: boolean;
   italic?: boolean;
   strike?: boolean;
+  underline?: boolean;
   highlight?: boolean;
   client_highlight?: boolean;
   unlink?: boolean;

--- a/test/block-kit.test.ts
+++ b/test/block-kit.test.ts
@@ -14,7 +14,7 @@ describe("Block Kit types", () => {
               {
                 type: "text",
                 text: "Hello world",
-                style: { bold: true, italic: true, strike: true, code: true },
+                style: { bold: true, italic: true, strike: true, underline: true, code: true },
               },
               {
                 type: "channel",


### PR DESCRIPTION
## Summary

Adds `underline?: boolean` to `RichTextSectionElementStyle`.

Slack's `rich_text` section elements support an `underline` style mark — both the desktop and mobile clients render it, and bots posting `rich_text` blocks with `style.underline: true` round-trip through the Web API. The type was missing the field, which forces callers to cast or intersect locally.

Because `RichTextSectionElementStyleWithCode extends RichTextSectionElementStyle`, this picks up `link`, `date`, and `text` element styles as well.

## Test plan

- [x] `npm run build` (tsc passes)
- [x] `npx vitest run` (25/25 pass)
- [x] Added `underline: true` to an existing style assertion in `test/block-kit.test.ts` to exercise the new field