### PR TITLE
Embed TS sources in sourcemaps to fix missing-source warnings

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
+    "inlineSources": true,
     "strict": true,
     "esModuleInterop": true,
     "allowJs": false


### PR DESCRIPTION
## Summary
- Adds `inlineSources: true` to `tsconfig.json` so published `dist/*.js.map` files embed their TypeScript sources via `sourcesContent`.
- The package excludes `src/` from publish (via `.npmignore`), so the existing maps' `../src/*.ts` references couldn't be resolved by consumers, producing warnings in environments like workerd / Cloudflare Workers' vitest integration.

Fixes #33

## Test plan
- [x] `npm run build:clean` succeeds
- [x] Verified `dist/index.js.map` contains a populated `sourcesContent` array alongside `sources`
- [ ] Confirm published tarball still does not include `src/` (no `.npmignore` change needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)