### PR TITLE
Add markdown, alert, card, carousel, plan, table, task_card blocks

### DIFF
--- a/src/block-kit/block-elements.ts
+++ b/src/block-kit/block-elements.ts
@@ -285,6 +285,13 @@ export interface IconButton extends ActionBlockElement<"icon_button"> {
   text: PlainTextField;
   value?: string;
 }
+// https://docs.slack.dev/reference/block-kit/block-elements/url-source-element
+// Used inside `task_card.sources`; cannot appear in other blocks.
+export interface UrlSource {
+  type: "url";
+  url: string;
+  text: string;
+}
 
 // https://api.slack.com/changelog/2019-09-what-they-see-is-what-you-get-and-more-and-less
 

--- a/src/block-kit/blocks.ts
+++ b/src/block-kit/blocks.ts
@@ -17,6 +17,7 @@ import type {
   RichTextInput,
   Timepicker,
   URLInput,
+  UrlSource,
   WorkflowButton,
 } from "./block-elements";
 import type { RichTextBlock } from "./rich-text-block";
@@ -38,7 +39,14 @@ export type AnyBlockType =
   | "file"
   | "header"
   | "video"
-  | "rich_text";
+  | "rich_text"
+  | "markdown"
+  | "alert"
+  | "card"
+  | "carousel"
+  | "plan"
+  | "table"
+  | "task_card";
 
 export interface Block<T extends AnyBlockType = AnyBlockType> {
   type: T;
@@ -60,7 +68,14 @@ export declare type AnyMessageBlock =
   | MessageInputBlock
   | SectionBlock
   | VideoBlock
-  | RichTextBlock;
+  | RichTextBlock
+  | MarkdownBlock
+  | AlertBlock
+  | CardBlock
+  | CarouselBlock
+  | PlanBlock
+  | TableBlock
+  | TaskCardBlock;
 
 export declare type AnyModalBlock =
   | ActionsBlock
@@ -72,7 +87,8 @@ export declare type AnyModalBlock =
   | ViewInputBlock
   | SectionBlock
   | VideoBlock
-  | RichTextBlock;
+  | RichTextBlock
+  | MarkdownBlock;
 
 export declare type AnyHomeTabBlock =
   | ActionsBlock
@@ -84,7 +100,8 @@ export declare type AnyHomeTabBlock =
   | ViewInputBlock
   | SectionBlock
   | VideoBlock
-  | RichTextBlock;
+  | RichTextBlock
+  | MarkdownBlock;
 
 // -----------------------------
 // Blocks
@@ -202,6 +219,7 @@ export interface SectionBlock extends Block<"section"> {
     | AnyMultiSelectElement
     | RadioButtons
     | Checkboxes;
+  expand?: boolean;
 }
 
 export interface VideoBlock extends Block<"video"> {
@@ -215,4 +233,68 @@ export interface VideoBlock extends Block<"video"> {
   provider_name?: string;
   provider_icon_url?: string;
   description?: PlainTextField;
+}
+
+// https://docs.slack.dev/reference/block-kit/blocks/markdown-block
+export interface MarkdownBlock extends Block<"markdown"> {
+  type: "markdown";
+  text: string;
+}
+
+// https://docs.slack.dev/reference/block-kit/blocks/alert-block
+export interface AlertBlock extends Block<"alert"> {
+  type: "alert";
+  text: AnyTextField;
+  level?: "default" | "info" | "warning" | "error" | "success";
+}
+
+// https://docs.slack.dev/reference/block-kit/blocks/card-block
+export interface CardBlock extends Block<"card"> {
+  type: "card";
+  hero_image?: ImageElement;
+  icon?: ImageElement;
+  title?: AnyTextField;
+  subtitle?: AnyTextField;
+  body?: AnyTextField;
+  actions?: Button[];
+}
+
+// https://docs.slack.dev/reference/block-kit/blocks/carousel-block
+export interface CarouselBlock extends Block<"carousel"> {
+  type: "carousel";
+  elements: CardBlock[];
+}
+
+// https://docs.slack.dev/reference/block-kit/blocks/plan-block
+export interface PlanBlock extends Block<"plan"> {
+  type: "plan";
+  title: PlainTextField;
+  tasks?: TaskCardBlock[];
+}
+
+// https://docs.slack.dev/reference/block-kit/blocks/table-block
+export interface TableRawTextCell {
+  type: "raw_text";
+  text: string;
+}
+export type TableCell = TableRawTextCell | RichTextBlock;
+export interface TableColumnSetting {
+  align?: "left" | "center" | "right";
+  is_wrapped?: boolean;
+}
+export interface TableBlock extends Block<"table"> {
+  type: "table";
+  rows: TableCell[][];
+  column_settings?: TableColumnSetting[];
+}
+
+// https://docs.slack.dev/reference/block-kit/blocks/task-card-block
+export interface TaskCardBlock extends Block<"task_card"> {
+  type: "task_card";
+  task_id: string;
+  title: string;
+  details?: RichTextBlock;
+  output?: RichTextBlock;
+  sources?: UrlSource[];
+  status?: "pending" | "in_progress" | "complete" | "error";
 }

--- a/src_deno/block-kit/block-elements.ts
+++ b/src_deno/block-kit/block-elements.ts
@@ -382,6 +382,13 @@ export interface IconButton extends ActionBlockElement<"icon_button"> {
   text: PlainTextField;
   value?: string;
 }
+// https://docs.slack.dev/reference/block-kit/block-elements/url-source-element
+// Used inside `task_card.sources`; cannot appear in other blocks.
+export interface UrlSource {
+  type: "url";
+  url: string;
+  text: string;
+}
 
 // https://api.slack.com/changelog/2019-09-what-they-see-is-what-you-get-and-more-and-less
 

--- a/src_deno/block-kit/blocks.ts
+++ b/src_deno/block-kit/blocks.ts
@@ -17,6 +17,7 @@ import type {
   RichTextInput,
   Timepicker,
   URLInput,
+  UrlSource,
   WorkflowButton,
 } from "./block-elements.ts";
 import type { RichTextBlock } from "./rich-text-block.ts";
@@ -38,7 +39,14 @@ export type AnyBlockType =
   | "file"
   | "header"
   | "video"
-  | "rich_text";
+  | "rich_text"
+  | "markdown"
+  | "alert"
+  | "card"
+  | "carousel"
+  | "plan"
+  | "table"
+  | "task_card";
 
 export interface Block<T extends AnyBlockType = AnyBlockType> {
   type: T;
@@ -60,7 +68,14 @@ export declare type AnyMessageBlock =
   | MessageInputBlock
   | SectionBlock
   | VideoBlock
-  | RichTextBlock;
+  | RichTextBlock
+  | MarkdownBlock
+  | AlertBlock
+  | CardBlock
+  | CarouselBlock
+  | PlanBlock
+  | TableBlock
+  | TaskCardBlock;
 
 export declare type AnyModalBlock =
   | ActionsBlock
@@ -72,7 +87,8 @@ export declare type AnyModalBlock =
   | ViewInputBlock
   | SectionBlock
   | VideoBlock
-  | RichTextBlock;
+  | RichTextBlock
+  | MarkdownBlock;
 
 export declare type AnyHomeTabBlock =
   | ActionsBlock
@@ -84,7 +100,8 @@ export declare type AnyHomeTabBlock =
   | ViewInputBlock
   | SectionBlock
   | VideoBlock
-  | RichTextBlock;
+  | RichTextBlock
+  | MarkdownBlock;
 
 // -----------------------------
 // Blocks
@@ -202,6 +219,7 @@ export interface SectionBlock extends Block<"section"> {
     | AnyMultiSelectElement
     | RadioButtons
     | Checkboxes;
+  expand?: boolean;
 }
 
 export interface VideoBlock extends Block<"video"> {
@@ -215,4 +233,68 @@ export interface VideoBlock extends Block<"video"> {
   provider_name?: string;
   provider_icon_url?: string;
   description?: PlainTextField;
+}
+
+// https://docs.slack.dev/reference/block-kit/blocks/markdown-block
+export interface MarkdownBlock extends Block<"markdown"> {
+  type: "markdown";
+  text: string;
+}
+
+// https://docs.slack.dev/reference/block-kit/blocks/alert-block
+export interface AlertBlock extends Block<"alert"> {
+  type: "alert";
+  text: AnyTextField;
+  level?: "default" | "info" | "warning" | "error" | "success";
+}
+
+// https://docs.slack.dev/reference/block-kit/blocks/card-block
+export interface CardBlock extends Block<"card"> {
+  type: "card";
+  hero_image?: ImageElement;
+  icon?: ImageElement;
+  title?: AnyTextField;
+  subtitle?: AnyTextField;
+  body?: AnyTextField;
+  actions?: Button[];
+}
+
+// https://docs.slack.dev/reference/block-kit/blocks/carousel-block
+export interface CarouselBlock extends Block<"carousel"> {
+  type: "carousel";
+  elements: CardBlock[];
+}
+
+// https://docs.slack.dev/reference/block-kit/blocks/plan-block
+export interface PlanBlock extends Block<"plan"> {
+  type: "plan";
+  title: PlainTextField;
+  tasks?: TaskCardBlock[];
+}
+
+// https://docs.slack.dev/reference/block-kit/blocks/table-block
+export interface TableRawTextCell {
+  type: "raw_text";
+  text: string;
+}
+export type TableCell = TableRawTextCell | RichTextBlock;
+export interface TableColumnSetting {
+  align?: "left" | "center" | "right";
+  is_wrapped?: boolean;
+}
+export interface TableBlock extends Block<"table"> {
+  type: "table";
+  rows: TableCell[][];
+  column_settings?: TableColumnSetting[];
+}
+
+// https://docs.slack.dev/reference/block-kit/blocks/task-card-block
+export interface TaskCardBlock extends Block<"task_card"> {
+  type: "task_card";
+  task_id: string;
+  title: string;
+  details?: RichTextBlock;
+  output?: RichTextBlock;
+  sources?: UrlSource[];
+  status?: "pending" | "in_progress" | "complete" | "error";
 }

--- a/test/block-kit.test.ts
+++ b/test/block-kit.test.ts
@@ -1,5 +1,20 @@
 import { assert, test, describe } from "vitest";
-import { AnyMessageBlock, AnyRichTextBlockElement, ContextActionsBlock, MessageInputBlock, RichTextBlock } from "../src/index";
+import {
+  AlertBlock,
+  AnyMessageBlock,
+  AnyModalBlock,
+  AnyRichTextBlockElement,
+  CardBlock,
+  CarouselBlock,
+  ContextActionsBlock,
+  MarkdownBlock,
+  MessageInputBlock,
+  PlanBlock,
+  RichTextBlock,
+  SectionBlock,
+  TableBlock,
+  TaskCardBlock,
+} from "../src/index";
 
 describe("Block Kit types", () => {
   test("parse rich text ones", async () => {
@@ -195,6 +210,200 @@ describe("Block Kit types", () => {
       },
     ];
     assert.isTrue(blocks.length > 0);
+  });
+
+  test("parse markdown blocks", async () => {
+    const block: MarkdownBlock = {
+      type: "markdown",
+      text: "**Lots of information here!!**",
+    };
+    const blocks: AnyMessageBlock[] = [block];
+    const modalBlocks: AnyModalBlock[] = [block];
+    assert.equal(blocks.length, 1);
+    assert.equal(modalBlocks.length, 1);
+  });
+
+  test("parse alert blocks", async () => {
+    const blocks: AlertBlock[] = [
+      {
+        type: "alert",
+        text: { type: "mrkdwn", text: "Heads up!" },
+      },
+      {
+        type: "alert",
+        block_id: "a1",
+        text: { type: "plain_text", text: "Something went wrong" },
+        level: "error",
+      },
+      {
+        type: "alert",
+        text: { type: "mrkdwn", text: "FYI" },
+        level: "info",
+      },
+      {
+        type: "alert",
+        text: { type: "mrkdwn", text: "Be careful" },
+        level: "warning",
+      },
+      {
+        type: "alert",
+        text: { type: "mrkdwn", text: "Nice!" },
+        level: "success",
+      },
+    ];
+    const messageBlocks: AnyMessageBlock[] = blocks;
+    assert.equal(messageBlocks.length, 5);
+  });
+
+  test("parse card blocks", async () => {
+    const block: CardBlock = {
+      type: "card",
+      icon: {
+        type: "image",
+        image_url: "https://picsum.photos/36/36",
+        alt_text: "Icon",
+      },
+      title: { type: "mrkdwn", text: "Lumon Industries" },
+      subtitle: { type: "mrkdwn", text: "Committed to work-life balance" },
+      hero_image: {
+        type: "image",
+        image_url: "https://picsum.photos/400/300",
+        alt_text: "Sample hero image",
+      },
+      body: { type: "mrkdwn", text: "Please enjoy each card equally." },
+      actions: [
+        {
+          type: "button",
+          text: { type: "plain_text", text: "Action Button" },
+          action_id: "button_action",
+        },
+      ],
+    };
+    const messageBlocks: AnyMessageBlock[] = [block];
+    assert.equal(messageBlocks.length, 1);
+    assert.equal(block.actions?.length, 1);
+  });
+
+  test("parse carousel blocks", async () => {
+    const block: CarouselBlock = {
+      type: "carousel",
+      elements: [
+        {
+          type: "card",
+          title: { type: "plain_text", text: "First card" },
+          body: { type: "mrkdwn", text: "Body 1" },
+        },
+        {
+          type: "card",
+          title: { type: "plain_text", text: "Second card" },
+          body: { type: "mrkdwn", text: "Body 2" },
+        },
+      ],
+    };
+    const messageBlocks: AnyMessageBlock[] = [block];
+    assert.equal(messageBlocks.length, 1);
+    assert.equal(block.elements.length, 2);
+  });
+
+  test("parse task_card blocks", async () => {
+    const block: TaskCardBlock = {
+      type: "task_card",
+      task_id: "task-1",
+      title: "Investigate failure",
+      status: "in_progress",
+      details: {
+        type: "rich_text",
+        elements: [
+          {
+            type: "rich_text_section",
+            elements: [{ type: "text", text: "Looking into the logs" }],
+          },
+        ],
+      },
+      output: {
+        type: "rich_text",
+        elements: [
+          {
+            type: "rich_text_section",
+            elements: [{ type: "text", text: "Found a stack trace" }],
+          },
+        ],
+      },
+      sources: [
+        { type: "url", url: "https://example.com/", text: "Reference" },
+      ],
+    };
+    const messageBlocks: AnyMessageBlock[] = [block];
+    assert.equal(messageBlocks.length, 1);
+    assert.equal(block.sources?.length, 1);
+    assert.equal(block.sources?.[0].type, "url");
+  });
+
+  test("parse plan blocks", async () => {
+    const block: PlanBlock = {
+      type: "plan",
+      title: { type: "plain_text", text: "Release plan" },
+      tasks: [
+        {
+          type: "task_card",
+          task_id: "t1",
+          title: "Run tests",
+          status: "complete",
+        },
+        {
+          type: "task_card",
+          task_id: "t2",
+          title: "Deploy",
+          status: "pending",
+        },
+      ],
+    };
+    const messageBlocks: AnyMessageBlock[] = [block];
+    assert.equal(messageBlocks.length, 1);
+    assert.equal(block.tasks?.length, 2);
+  });
+
+  test("parse table blocks", async () => {
+    const block: TableBlock = {
+      type: "table",
+      rows: [
+        [
+          { type: "raw_text", text: "Name" },
+          { type: "raw_text", text: "Score" },
+        ],
+        [
+          { type: "raw_text", text: "Alice" },
+          {
+            type: "rich_text",
+            elements: [
+              {
+                type: "rich_text_section",
+                elements: [
+                  { type: "text", text: "100", style: { bold: true } },
+                ],
+              },
+            ],
+          },
+        ],
+      ],
+      column_settings: [
+        { align: "left", is_wrapped: false },
+        { align: "right" },
+      ],
+    };
+    const messageBlocks: AnyMessageBlock[] = [block];
+    assert.equal(messageBlocks.length, 1);
+    assert.equal(block.rows.length, 2);
+    assert.equal(block.column_settings?.length, 2);
+  });
+
+  test("section block supports expand", async () => {
+    const block: SectionBlock = {
+      type: "section",
+      text: { type: "mrkdwn", text: "long content..." },
+      expand: true,
+    };
+    assert.equal(block.expand, true);
   });
 
   test("parse context actions blocks", async () => {


### PR DESCRIPTION
## Summary
- Adds Block Kit block types missing from the repo: \`markdown\`, \`alert\`, \`card\`, \`carousel\`, \`plan\`, \`table\` (with \`raw_text\`/\`rich_text\` cells + \`column_settings\`), and \`task_card\`.
- Adds the \`url_source\` element (used inside \`task_card.sources\`) and \`expand?: boolean\` on \`SectionBlock\`.
- Mirrors changes to \`src_deno\` and covers each new shape with vitest type tests.

## Test plan
- [x] \`npx vitest run\` — 33 tests pass (14 in \`test/block-kit.test.ts\`, was 5)
- [x] \`npx tsc --noEmit\` — clean
- [x] \`deno check src_deno/mod.ts\` — clean
- [x] \`deno lint\` — clean
- [x] \`deno fmt --check\` — no new failures (one pre-existing fmt issue from #29 on \`FeedbackButtons\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)