### PR TITLE
RELEASING.md: add GitHub Release step with v-prefixed tags

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -35,7 +35,6 @@ How to publish a new version of `slack-web-api-client` to npm.
    git tag vX.Y.Z
    git push origin vX.Y.Z
    ```
-   (Older tags `1.0.0` through `1.1.12` predate this convention and lack the `v` prefix — leave them as-is.)
 7. **Publish a GitHub Release** at `vX.Y.Z`. Match the style of recent slack-edge releases: title equal to the tag, body a short bulleted changelog of changes since the previous version (no headings or extra prose).
    ```
    gh release create vX.Y.Z --title vX.Y.Z --latest --notes "- First change

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -30,11 +30,18 @@ How to publish a new version of `slack-web-api-client` to npm.
    ```
    npm publish --otp=123456
    ```
-6. **Tag the published commit** (lightweight tag, no `v` prefix — matches the existing tag history):
+6. **Tag the published commit.** Lightweight tag with a `v` prefix, matching the convention used in [`slack-edge/slack-edge`](https://github.com/slack-edge/slack-edge/releases):
    ```
-   git tag X.Y.Z
-   git push origin X.Y.Z
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
    ```
+   (Older tags `1.0.0` through `1.1.12` predate this convention and lack the `v` prefix — leave them as-is.)
+7. **Publish a GitHub Release** at `vX.Y.Z`. Match the style of recent slack-edge releases: title equal to the tag, body a short bulleted changelog of changes since the previous version (no headings or extra prose).
+   ```
+   gh release create vX.Y.Z --title vX.Y.Z --latest --notes "- First change
+   - Second change"
+   ```
+   Or omit `--notes` to draft the body interactively in `$EDITOR`.
 
 ## Verifying the release
 


### PR DESCRIPTION
## Summary
Stacks on #39. Adds two things to `RELEASING.md`:

- **`v` prefix on git tags going forward.** Matches the convention used in [`slack-edge/slack-edge`](https://github.com/slack-edge/slack-edge/releases) (whose latest release is `v1.3.16`). The existing tag history here (`1.0.0` … `1.1.12`) is called out as legacy so a future maintainer isn't tripped up by the inconsistency.
- **A GitHub Releases step.** Title equals the tag (`vX.Y.Z`), body is a short bulleted changelog with no headings or extra prose — same shape as the recent slack-edge release notes. Includes the `gh release create` invocation.

## Ordering
- Merge #39 first; this PR's diff will then narrow to just the new step 6/7 wording.

## Note on the 1.1.12 release
The 1.1.12 tag was created before this convention change, so it's `1.1.12` not `v1.1.12`, and there's no GitHub Release for it. The doc explicitly grandfathers that. Happy to backfill a `v1.1.12` GitHub Release pointing at the existing tag if you want — just say the word.

## Test plan
- [ ] Merge #39, confirm this PR's diff narrows to the intended changes
- [ ] Next release: follow steps 6–7 end-to-end and tweak the doc if anything is off

🤖 Generated with [Claude Code](https://claude.com/claude-code)