### PR TITLE
Add Dependabot config for npm and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` to enable weekly Dependabot updates for npm dependencies and GitHub Actions.
- Sets an open-PR limit of 10 per ecosystem.

## Test plan
- [ ] Verify Dependabot is enabled in repo settings and runs against this config after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)