### PR TITLE
feat(types): streaming chunks, entity unfurls, assistant loading_messages

### DIFF
--- a/src/block-kit/message-metadata.ts
+++ b/src/block-kit/message-metadata.ts
@@ -1,3 +1,7 @@
+import type { AnyOption } from "./options";
+import type { AnySlackFile } from "./slack-files";
+import type { PlainTextField } from "./text-fields";
+
 export interface MessageMetadata<T extends string = string> {
   event_type: T;
   event_payload: {
@@ -6,4 +10,275 @@ export interface MessageMetadata<T extends string = string> {
 }
 export interface MessageMetadataEventPayload {
   [key: string]: null | string | number | boolean;
+}
+
+/*
+ * Work-object entity metadata, attached to a message via `chat.unfurl`.
+ * Mirrors the `EntityMetadata` type tree from @slack/types (message-metadata),
+ * mapped onto this package's own block-kit primitives.
+ */
+
+/** Known work-object entity types. */
+export type EntityType =
+  | "slack#/entities/task"
+  | "slack#/entities/file"
+  | "slack#/entities/item"
+  | "slack#/entities/incident"
+  | "slack#/entities/content_item"
+  | string;
+
+/** Known custom-field value types. */
+export type CustomFieldType =
+  | "integer"
+  | "string"
+  | "array"
+  | "slack#/types/date"
+  | "slack#/types/timestamp"
+  | "slack#/types/image"
+  | "slack#/types/channel_id"
+  | "slack#/types/user"
+  | "slack#/types/entity_ref"
+  | "boolean"
+  | "slack#/types/link"
+  | "slack#/types/email"
+  | string;
+
+/** Reference (and optional type) used to identify an entity within the developer's system. */
+export interface ExternalRef {
+  id: string;
+  type?: string;
+}
+
+/** Slack file reference embedded directly in an entity payload. */
+export interface FileEntitySlackFile {
+  id: string;
+  type?: string;
+}
+
+/** Product or field icon, sourced from a URL or a Slack file. */
+export interface EntityIconField {
+  alt_text: string;
+  url?: string;
+  slack_file?: {
+    id?: string;
+    url?: string;
+  };
+}
+
+/** Inline-edit affordance describing how a field may be modified from the unfurl. */
+export interface EntityEditSupport {
+  enabled: boolean;
+  placeholder?: PlainTextField;
+  hint?: PlainTextField;
+  optional?: boolean;
+  select?: {
+    current_value?: string;
+    current_values?: string[];
+    static_options?: AnyOption[];
+    fetch_options_dynamically?: boolean;
+    min_query_length?: number;
+  };
+  number?: {
+    is_decimal_allowed?: boolean;
+    min_value?: number;
+    max_value?: number;
+  };
+  text?: {
+    min_length?: number;
+    max_length?: number;
+  };
+}
+
+/** Full-size preview availability and source for an entity. */
+export interface EntityFullSizePreview {
+  is_supported: boolean;
+  preview_url?: string;
+  mime_type?: string;
+  error?: {
+    code: string;
+    message?: string;
+  };
+}
+
+/** Top-level presentation attributes for an entity (title, icon, locale, etc.). */
+export interface EntityAttributes {
+  title: {
+    text: string;
+    edit?: EntityEditSupport;
+  };
+  display_type?: string;
+  display_id?: string;
+  product_icon?: EntityIconField;
+  product_name?: string;
+  locale?: string;
+  full_size_preview?: EntityFullSizePreview;
+  metadata_last_modified?: number;
+}
+
+export interface EntityUserIDField {
+  user_id: string;
+}
+export interface EntityUserField {
+  text: string;
+  url?: string;
+  email?: string;
+  icon?: EntityIconField;
+}
+export interface EntityRefField {
+  entity_url: string;
+  external_ref: ExternalRef;
+  title: string;
+  display_type?: string;
+  icon?: EntityIconField;
+}
+export interface EntityTypedField {
+  type: string;
+  label?: string;
+  value?: string | number;
+  link?: string;
+  icon?: EntityIconField;
+  long?: boolean;
+  format?: string;
+  image_url?: string;
+  slack_file?: AnySlackFile;
+  alt_text?: string;
+  edit?: EntityEditSupport;
+  tag_color?: string;
+  user?: EntityUserIDField | EntityUserField;
+  entity_ref?: EntityRefField;
+}
+export interface EntityArrayItemField extends Omit<EntityTypedField, "type"> {
+  type?: string;
+}
+export interface EntityStringField {
+  value: string;
+  label?: string;
+  format?: string;
+  link?: string;
+  icon?: EntityIconField;
+  long?: boolean;
+  type?: string;
+  tag_color?: string;
+  edit?: EntityEditSupport;
+}
+export interface EntityTimestampField {
+  value: number;
+  label?: string;
+  type?: string;
+  edit?: EntityEditSupport;
+}
+export interface EntityImageField {
+  alt_text: string;
+  label?: string;
+  image_url?: string;
+  slack_file?: AnySlackFile;
+  title?: string;
+  type?: string;
+}
+export interface EntityBooleanCheckboxField {
+  type: string;
+  text: string;
+  description?: string;
+}
+export interface EntityBooleanTextField {
+  type: string;
+  true_text: string;
+  false_text: string;
+  true_description?: string;
+  false_description?: string;
+}
+
+/** Per-entity-type field bundles. Only one applies for a given `entity_type`. */
+export interface FileEntityFields {
+  preview?: EntityImageField;
+  created_by?: EntityTypedField;
+  date_created?: EntityTimestampField;
+  date_updated?: EntityTimestampField;
+  last_modified_by?: EntityTypedField;
+  file_size?: EntityStringField;
+  mime_type?: EntityStringField;
+  full_size_preview?: EntityFullSizePreview;
+}
+export interface TaskEntityFields {
+  description?: EntityStringField;
+  created_by?: EntityTypedField;
+  date_created?: EntityTimestampField;
+  date_updated?: EntityTimestampField;
+  assignee?: EntityTypedField;
+  status?: EntityStringField;
+  due_date?: EntityTypedField;
+  priority?: EntityStringField;
+}
+export interface IncidentEntityFields {
+  status?: EntityStringField;
+  priority?: EntityStringField;
+  urgency?: EntityStringField;
+  created_by?: EntityTypedField;
+  assigned_to?: EntityTypedField;
+  date_created?: EntityTimestampField;
+  date_updated?: EntityTimestampField;
+  description?: EntityStringField;
+  service?: EntityStringField;
+}
+export interface ContentItemEntityFields {
+  preview?: EntityImageField;
+  description?: EntityStringField;
+  created_by?: EntityTypedField;
+  date_created?: EntityTimestampField;
+  date_updated?: EntityTimestampField;
+  last_modified_by?: EntityTypedField;
+}
+
+/** Developer-defined custom field rendered on the entity unfurl. */
+export interface EntityCustomField {
+  label: string;
+  key: string;
+  type: CustomFieldType;
+  value?: string | number | EntityArrayItemField[];
+  link?: string;
+  icon?: EntityIconField;
+  long?: boolean;
+  format?: string;
+  image_url?: string;
+  slack_file?: AnySlackFile;
+  alt_text?: string;
+  tag_color?: string;
+  edit?: EntityEditSupport;
+  item_type?: string;
+  user?: EntityUserIDField | EntityUserField;
+  entity_ref?: EntityRefField;
+  boolean?: EntityBooleanCheckboxField | EntityBooleanTextField;
+}
+
+/** Action button rendered in an entity's primary or overflow action group. */
+export interface EntityActionButton {
+  text: string;
+  action_id: string;
+  value?: string;
+  style?: string;
+  url?: string;
+  accessibility_label?: string;
+  processing_state?: {
+    enabled: boolean;
+    interstitial_text?: string;
+  };
+}
+
+/** Metadata that represents a work-object entity, attached to a message via `chat.unfurl`. */
+export interface EntityMetadata {
+  entity_type: EntityType;
+  entity_payload: {
+    attributes: EntityAttributes;
+    fields?: ContentItemEntityFields | FileEntityFields | IncidentEntityFields | TaskEntityFields;
+    custom_fields?: EntityCustomField[];
+    slack_file?: FileEntitySlackFile;
+    display_order?: string[];
+    actions?: {
+      primary_actions?: EntityActionButton[];
+      overflow_actions?: EntityActionButton[];
+    };
+  };
+  external_ref: ExternalRef;
+  url: string;
+  app_unfurl_url?: string;
 }

--- a/src/client/request.ts
+++ b/src/client/request.ts
@@ -2,7 +2,7 @@ import type { EventTriggerSettings, ScheduleTriggerSettings, WebhookTriggerSetti
 import type { AnyMessageBlock } from "../block-kit/blocks";
 import type { LinkUnfurls } from "../block-kit/link-unfurls";
 import type { MessageAttachment } from "../block-kit/message-attachment";
-import type { MessageMetadata } from "../block-kit/message-metadata";
+import type { EntityMetadata, MessageMetadata } from "../block-kit/message-metadata";
 import type { ModalView, HomeTabView } from "../block-kit/views";
 import type { ManifestParams } from "../manifest/manifest-params";
 
@@ -552,6 +552,7 @@ export interface AssistantThreadsSetStatusRequest extends SlackAPIRequest {
   channel_id: string;
   thread_ts: string;
   status: string;
+  loading_messages?: string[];
 }
 export interface AssistantThreadsSetSuggestedPromptsRequest extends SlackAPIRequest {
   channel_id: string;
@@ -761,7 +762,12 @@ interface SourceAndUnfurlIDRequest {
 }
 export type ChatUnfurlRequest = (ChannelAndTSRequest | SourceAndUnfurlIDRequest) &
   SlackAPIRequest & {
-    unfurls: LinkUnfurls;
+    /** Provide either `unfurls` (URL -> unfurl blocks) or `metadata` (entity unfurls), not both. */
+    unfurls?: LinkUnfurls;
+    /** Unfurl metadata attaching an array of entities to the message (work-object unfurls). */
+    metadata?: Partial<MessageMetadata> & {
+      entities: EntityMetadata[];
+    };
     user_auth_message?: string;
     user_auth_required?: boolean;
     user_auth_url?: string;
@@ -783,15 +789,51 @@ export interface ChatUpdateRequest extends SlackAPIRequest {
   as_user?: boolean;
 }
 
+/** A URL source reference rendered beneath a streamed task. */
+export interface MessageChunkURLSource {
+  type: "url";
+  url: string;
+  text?: string;
+}
+/** Streams an array of Block Kit blocks within a message stream. */
+export interface BlocksChunk {
+  type: "blocks";
+  blocks: AnyMessageBlock[];
+}
+/** Streams markdown-formatted text within a message stream. */
+export interface MarkdownTextChunk {
+  type: "markdown_text";
+  text: string;
+}
+/** Updates the title of the streamed plan. */
+export interface PlanUpdateChunk {
+  type: "plan_update";
+  title: string;
+}
+/** Updates a task's progress in a timeline-style UI. */
+export interface TaskUpdateChunk {
+  type: "task_update";
+  id: string;
+  title: string;
+  status: "pending" | "in_progress" | "complete" | "error";
+  details?: string;
+  output?: string;
+  sources?: MessageChunkURLSource[];
+}
+/** Any streaming message chunk accepted by the chat streaming methods. */
+export type AnyMessageChunk = BlocksChunk | MarkdownTextChunk | PlanUpdateChunk | TaskUpdateChunk;
 export interface ChatAppendStreamRequest extends SlackAPIRequest {
   channel: string;
   ts: string;
-  markdown_text: string;
+  markdown_text?: string;
+  chunks?: AnyMessageChunk[];
 }
 export interface ChatStartStreamRequest extends SlackAPIRequest {
   channel: string;
   thread_ts: string;
   markdown_text?: string;
+  chunks?: AnyMessageChunk[];
+  task_display_mode?: string;
   recipient_user_id?: string;
   recipient_team_id?: string;
 }
@@ -799,6 +841,7 @@ export interface ChatStopStreamRequest extends SlackAPIRequest {
   channel: string;
   ts: string;
   markdown_text?: string;
+  chunks?: AnyMessageChunk[];
   blocks?: AnyMessageBlock[];
   metadata?: MessageMetadata;
 }

--- a/src_deno/block-kit/block-elements.ts
+++ b/src_deno/block-kit/block-elements.ts
@@ -371,7 +371,8 @@ export interface FeedbackButton {
   text: PlainTextField;
   value: string;
 }
-export interface FeedbackButtons extends ActionBlockElement<"feedback_buttons"> {
+export interface FeedbackButtons
+  extends ActionBlockElement<"feedback_buttons"> {
   type: "feedback_buttons";
   positive_button: FeedbackButton;
   negative_button: FeedbackButton;
@@ -509,6 +510,7 @@ export interface RichTextSectionElementStyle {
   bold?: boolean;
   italic?: boolean;
   strike?: boolean;
+  underline?: boolean;
   highlight?: boolean;
   client_highlight?: boolean;
   unlink?: boolean;

--- a/src_deno/block-kit/message-metadata.ts
+++ b/src_deno/block-kit/message-metadata.ts
@@ -1,3 +1,7 @@
+import type { AnyOption } from "./options.ts";
+import type { AnySlackFile } from "./slack-files.ts";
+import type { PlainTextField } from "./text-fields.ts";
+
 export interface MessageMetadata<T extends string = string> {
   event_type: T;
   event_payload: {
@@ -12,4 +16,279 @@ export interface MessageMetadata<T extends string = string> {
 }
 export interface MessageMetadataEventPayload {
   [key: string]: null | string | number | boolean;
+}
+
+/*
+ * Work-object entity metadata, attached to a message via `chat.unfurl`.
+ * Mirrors the `EntityMetadata` type tree from @slack/types (message-metadata),
+ * mapped onto this package's own block-kit primitives.
+ */
+
+/** Known work-object entity types. */
+export type EntityType =
+  | "slack#/entities/task"
+  | "slack#/entities/file"
+  | "slack#/entities/item"
+  | "slack#/entities/incident"
+  | "slack#/entities/content_item"
+  | string;
+
+/** Known custom-field value types. */
+export type CustomFieldType =
+  | "integer"
+  | "string"
+  | "array"
+  | "slack#/types/date"
+  | "slack#/types/timestamp"
+  | "slack#/types/image"
+  | "slack#/types/channel_id"
+  | "slack#/types/user"
+  | "slack#/types/entity_ref"
+  | "boolean"
+  | "slack#/types/link"
+  | "slack#/types/email"
+  | string;
+
+/** Reference (and optional type) used to identify an entity within the developer's system. */
+export interface ExternalRef {
+  id: string;
+  type?: string;
+}
+
+/** Slack file reference embedded directly in an entity payload. */
+export interface FileEntitySlackFile {
+  id: string;
+  type?: string;
+}
+
+/** Product or field icon, sourced from a URL or a Slack file. */
+export interface EntityIconField {
+  alt_text: string;
+  url?: string;
+  slack_file?: {
+    id?: string;
+    url?: string;
+  };
+}
+
+/** Inline-edit affordance describing how a field may be modified from the unfurl. */
+export interface EntityEditSupport {
+  enabled: boolean;
+  placeholder?: PlainTextField;
+  hint?: PlainTextField;
+  optional?: boolean;
+  select?: {
+    current_value?: string;
+    current_values?: string[];
+    static_options?: AnyOption[];
+    fetch_options_dynamically?: boolean;
+    min_query_length?: number;
+  };
+  number?: {
+    is_decimal_allowed?: boolean;
+    min_value?: number;
+    max_value?: number;
+  };
+  text?: {
+    min_length?: number;
+    max_length?: number;
+  };
+}
+
+/** Full-size preview availability and source for an entity. */
+export interface EntityFullSizePreview {
+  is_supported: boolean;
+  preview_url?: string;
+  mime_type?: string;
+  error?: {
+    code: string;
+    message?: string;
+  };
+}
+
+/** Top-level presentation attributes for an entity (title, icon, locale, etc.). */
+export interface EntityAttributes {
+  title: {
+    text: string;
+    edit?: EntityEditSupport;
+  };
+  display_type?: string;
+  display_id?: string;
+  product_icon?: EntityIconField;
+  product_name?: string;
+  locale?: string;
+  full_size_preview?: EntityFullSizePreview;
+  metadata_last_modified?: number;
+}
+
+export interface EntityUserIDField {
+  user_id: string;
+}
+export interface EntityUserField {
+  text: string;
+  url?: string;
+  email?: string;
+  icon?: EntityIconField;
+}
+export interface EntityRefField {
+  entity_url: string;
+  external_ref: ExternalRef;
+  title: string;
+  display_type?: string;
+  icon?: EntityIconField;
+}
+export interface EntityTypedField {
+  type: string;
+  label?: string;
+  value?: string | number;
+  link?: string;
+  icon?: EntityIconField;
+  long?: boolean;
+  format?: string;
+  image_url?: string;
+  slack_file?: AnySlackFile;
+  alt_text?: string;
+  edit?: EntityEditSupport;
+  tag_color?: string;
+  user?: EntityUserIDField | EntityUserField;
+  entity_ref?: EntityRefField;
+}
+export interface EntityArrayItemField extends Omit<EntityTypedField, "type"> {
+  type?: string;
+}
+export interface EntityStringField {
+  value: string;
+  label?: string;
+  format?: string;
+  link?: string;
+  icon?: EntityIconField;
+  long?: boolean;
+  type?: string;
+  tag_color?: string;
+  edit?: EntityEditSupport;
+}
+export interface EntityTimestampField {
+  value: number;
+  label?: string;
+  type?: string;
+  edit?: EntityEditSupport;
+}
+export interface EntityImageField {
+  alt_text: string;
+  label?: string;
+  image_url?: string;
+  slack_file?: AnySlackFile;
+  title?: string;
+  type?: string;
+}
+export interface EntityBooleanCheckboxField {
+  type: string;
+  text: string;
+  description?: string;
+}
+export interface EntityBooleanTextField {
+  type: string;
+  true_text: string;
+  false_text: string;
+  true_description?: string;
+  false_description?: string;
+}
+
+/** Per-entity-type field bundles. Only one applies for a given `entity_type`. */
+export interface FileEntityFields {
+  preview?: EntityImageField;
+  created_by?: EntityTypedField;
+  date_created?: EntityTimestampField;
+  date_updated?: EntityTimestampField;
+  last_modified_by?: EntityTypedField;
+  file_size?: EntityStringField;
+  mime_type?: EntityStringField;
+  full_size_preview?: EntityFullSizePreview;
+}
+export interface TaskEntityFields {
+  description?: EntityStringField;
+  created_by?: EntityTypedField;
+  date_created?: EntityTimestampField;
+  date_updated?: EntityTimestampField;
+  assignee?: EntityTypedField;
+  status?: EntityStringField;
+  due_date?: EntityTypedField;
+  priority?: EntityStringField;
+}
+export interface IncidentEntityFields {
+  status?: EntityStringField;
+  priority?: EntityStringField;
+  urgency?: EntityStringField;
+  created_by?: EntityTypedField;
+  assigned_to?: EntityTypedField;
+  date_created?: EntityTimestampField;
+  date_updated?: EntityTimestampField;
+  description?: EntityStringField;
+  service?: EntityStringField;
+}
+export interface ContentItemEntityFields {
+  preview?: EntityImageField;
+  description?: EntityStringField;
+  created_by?: EntityTypedField;
+  date_created?: EntityTimestampField;
+  date_updated?: EntityTimestampField;
+  last_modified_by?: EntityTypedField;
+}
+
+/** Developer-defined custom field rendered on the entity unfurl. */
+export interface EntityCustomField {
+  label: string;
+  key: string;
+  type: CustomFieldType;
+  value?: string | number | EntityArrayItemField[];
+  link?: string;
+  icon?: EntityIconField;
+  long?: boolean;
+  format?: string;
+  image_url?: string;
+  slack_file?: AnySlackFile;
+  alt_text?: string;
+  tag_color?: string;
+  edit?: EntityEditSupport;
+  item_type?: string;
+  user?: EntityUserIDField | EntityUserField;
+  entity_ref?: EntityRefField;
+  boolean?: EntityBooleanCheckboxField | EntityBooleanTextField;
+}
+
+/** Action button rendered in an entity's primary or overflow action group. */
+export interface EntityActionButton {
+  text: string;
+  action_id: string;
+  value?: string;
+  style?: string;
+  url?: string;
+  accessibility_label?: string;
+  processing_state?: {
+    enabled: boolean;
+    interstitial_text?: string;
+  };
+}
+
+/** Metadata that represents a work-object entity, attached to a message via `chat.unfurl`. */
+export interface EntityMetadata {
+  entity_type: EntityType;
+  entity_payload: {
+    attributes: EntityAttributes;
+    fields?:
+      | ContentItemEntityFields
+      | FileEntityFields
+      | IncidentEntityFields
+      | TaskEntityFields;
+    custom_fields?: EntityCustomField[];
+    slack_file?: FileEntitySlackFile;
+    display_order?: string[];
+    actions?: {
+      primary_actions?: EntityActionButton[];
+      overflow_actions?: EntityActionButton[];
+    };
+  };
+  external_ref: ExternalRef;
+  url: string;
+  app_unfurl_url?: string;
 }

--- a/src_deno/client/request.ts
+++ b/src_deno/client/request.ts
@@ -6,7 +6,10 @@ import type {
 import type { AnyMessageBlock } from "../block-kit/blocks.ts";
 import type { LinkUnfurls } from "../block-kit/link-unfurls.ts";
 import type { MessageAttachment } from "../block-kit/message-attachment.ts";
-import type { MessageMetadata } from "../block-kit/message-metadata.ts";
+import type {
+  EntityMetadata,
+  MessageMetadata,
+} from "../block-kit/message-metadata.ts";
 import type { HomeTabView, ModalView } from "../block-kit/views.ts";
 import type { ManifestParams } from "../manifest/manifest-params.ts";
 
@@ -597,6 +600,7 @@ export interface AssistantThreadsSetStatusRequest extends SlackAPIRequest {
   channel_id: string;
   thread_ts: string;
   status: string;
+  loading_messages?: string[];
 }
 export interface AssistantThreadsSetSuggestedPromptsRequest
   extends SlackAPIRequest {
@@ -817,7 +821,12 @@ export type ChatUnfurlRequest =
   & (ChannelAndTSRequest | SourceAndUnfurlIDRequest)
   & SlackAPIRequest
   & {
-    unfurls: LinkUnfurls;
+    /** Provide either `unfurls` (URL -> unfurl blocks) or `metadata` (entity unfurls), not both. */
+    unfurls?: LinkUnfurls;
+    /** Unfurl metadata attaching an array of entities to the message (work-object unfurls). */
+    metadata?: Partial<MessageMetadata> & {
+      entities: EntityMetadata[];
+    };
     user_auth_message?: string;
     user_auth_required?: boolean;
     user_auth_url?: string;
@@ -839,15 +848,55 @@ export interface ChatUpdateRequest extends SlackAPIRequest {
   as_user?: boolean;
 }
 
+/** A URL source reference rendered beneath a streamed task. */
+export interface MessageChunkURLSource {
+  type: "url";
+  url: string;
+  text?: string;
+}
+/** Streams an array of Block Kit blocks within a message stream. */
+export interface BlocksChunk {
+  type: "blocks";
+  blocks: AnyMessageBlock[];
+}
+/** Streams markdown-formatted text within a message stream. */
+export interface MarkdownTextChunk {
+  type: "markdown_text";
+  text: string;
+}
+/** Updates the title of the streamed plan. */
+export interface PlanUpdateChunk {
+  type: "plan_update";
+  title: string;
+}
+/** Updates a task's progress in a timeline-style UI. */
+export interface TaskUpdateChunk {
+  type: "task_update";
+  id: string;
+  title: string;
+  status: "pending" | "in_progress" | "complete" | "error";
+  details?: string;
+  output?: string;
+  sources?: MessageChunkURLSource[];
+}
+/** Any streaming message chunk accepted by the chat streaming methods. */
+export type AnyMessageChunk =
+  | BlocksChunk
+  | MarkdownTextChunk
+  | PlanUpdateChunk
+  | TaskUpdateChunk;
 export interface ChatAppendStreamRequest extends SlackAPIRequest {
   channel: string;
   ts: string;
-  markdown_text: string;
+  markdown_text?: string;
+  chunks?: AnyMessageChunk[];
 }
 export interface ChatStartStreamRequest extends SlackAPIRequest {
   channel: string;
   thread_ts: string;
   markdown_text?: string;
+  chunks?: AnyMessageChunk[];
+  task_display_mode?: string;
   recipient_user_id?: string;
   recipient_team_id?: string;
 }
@@ -855,6 +904,7 @@ export interface ChatStopStreamRequest extends SlackAPIRequest {
   channel: string;
   ts: string;
   markdown_text?: string;
+  chunks?: AnyMessageChunk[];
   blocks?: AnyMessageBlock[];
   metadata?: MessageMetadata;
 }

--- a/test/streaming-chunks-and-entity-unfurl.test.ts
+++ b/test/streaming-chunks-and-entity-unfurl.test.ts
@@ -1,0 +1,146 @@
+import { afterAll, afterEach, assert, beforeAll, describe, test } from "vitest";
+import { SlackAPIClient } from "../src/index";
+
+import { setupServer } from "msw/node";
+import { http, HttpResponse } from "msw";
+
+const server = setupServer();
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterAll(() => server.close());
+afterEach(() => server.resetHandlers());
+
+/**
+ * Captures the urlencoded form body of a single Slack API call so individual
+ * fields can be asserted against their serialized wire representation.
+ */
+function captureFormBody(method: string): { body: Promise<URLSearchParams> } {
+  let resolveBody: (params: URLSearchParams) => void;
+  const body = new Promise<URLSearchParams>((resolve) => {
+    resolveBody = resolve;
+  });
+  server.use(
+    http.post(`https://slack.com/api/${method}`, async ({ request }) => {
+      const text = await request.text();
+      resolveBody(new URLSearchParams(text));
+      return HttpResponse.json({ ok: true });
+    }),
+  );
+  return { body };
+}
+
+describe("chat streaming chunks", () => {
+  test("chat.startStream serializes chunks as JSON and passes task_display_mode through", async () => {
+    const { body } = captureFormBody("chat.startStream");
+    const client = new SlackAPIClient("xoxb-valid", { logLevel: "DEBUG" });
+
+    const response = await client.chat.startStream({
+      channel: "C12345",
+      thread_ts: "1700000000.000100",
+      task_display_mode: "timeline",
+      chunks: [
+        { type: "plan_update", title: "Researching" },
+        {
+          type: "task_update",
+          id: "task-1",
+          title: "Search the docs",
+          status: "in_progress",
+          sources: [{ type: "url", url: "https://example.com", text: "Example" }],
+        },
+      ],
+    });
+
+    assert.equal(response.error, undefined);
+    const params = await body;
+    assert.equal(params.get("task_display_mode"), "timeline");
+    assert.equal(
+      params.get("chunks"),
+      '[{"type":"plan_update","title":"Researching"},{"type":"task_update","id":"task-1","title":"Search the docs","status":"in_progress","sources":[{"type":"url","url":"https://example.com","text":"Example"}]}]',
+    );
+  });
+
+  test("chat.appendStream accepts chunks without markdown_text", async () => {
+    const { body } = captureFormBody("chat.appendStream");
+    const client = new SlackAPIClient("xoxb-valid", { logLevel: "DEBUG" });
+
+    const response = await client.chat.appendStream({
+      channel: "C12345",
+      ts: "1700000000.000200",
+      chunks: [{ type: "markdown_text", text: "Partial answer" }],
+    });
+
+    assert.equal(response.error, undefined);
+    const params = await body;
+    // markdown_text is now optional and was omitted, so it must not be sent.
+    assert.equal(params.get("markdown_text"), null);
+    assert.equal(params.get("chunks"), '[{"type":"markdown_text","text":"Partial answer"}]');
+  });
+
+  test("chat.stopStream serializes a final blocks chunk", async () => {
+    const { body } = captureFormBody("chat.stopStream");
+    const client = new SlackAPIClient("xoxb-valid", { logLevel: "DEBUG" });
+
+    const response = await client.chat.stopStream({
+      channel: "C12345",
+      ts: "1700000000.000300",
+      chunks: [{ type: "blocks", blocks: [{ type: "divider" }] }],
+    });
+
+    assert.equal(response.error, undefined);
+    const params = await body;
+    assert.equal(params.get("chunks"), '[{"type":"blocks","blocks":[{"type":"divider"}]}]');
+  });
+});
+
+describe("chat.unfurl entity metadata", () => {
+  test("serializes metadata.entities as JSON when unfurls is omitted", async () => {
+    const { body } = captureFormBody("chat.unfurl");
+    const client = new SlackAPIClient("xoxb-valid", { logLevel: "DEBUG" });
+
+    const response = await client.chat.unfurl({
+      channel: "C12345",
+      ts: "1700000000.000400",
+      metadata: {
+        entities: [
+          {
+            entity_type: "slack#/entities/task",
+            entity_payload: {
+              attributes: { title: { text: "Ticket #42" } },
+              fields: { status: { value: "Open" } },
+            },
+            external_ref: { id: "TICKET-42", type: "ticket" },
+            url: "https://example.com/tickets/42",
+          },
+        ],
+      },
+    });
+
+    assert.equal(response.error, undefined);
+    const params = await body;
+    // unfurls is now optional; an entity-only unfurl must not send an empty unfurls field.
+    assert.equal(params.get("unfurls"), null);
+    assert.equal(
+      params.get("metadata"),
+      '{"entities":[{"entity_type":"slack#/entities/task","entity_payload":{"attributes":{"title":{"text":"Ticket #42"}},"fields":{"status":{"value":"Open"}}},"external_ref":{"id":"TICKET-42","type":"ticket"},"url":"https://example.com/tickets/42"}]}',
+    );
+  });
+});
+
+describe("assistant.threads.setStatus loading_messages", () => {
+  test("serializes loading_messages as a comma-joined string", async () => {
+    const { body } = captureFormBody("assistant.threads.setStatus");
+    const client = new SlackAPIClient("xoxb-valid", { logLevel: "DEBUG" });
+
+    const response = await client.assistant.threads.setStatus({
+      channel_id: "C12345",
+      thread_ts: "1700000000.000500",
+      status: "is thinking...",
+      loading_messages: ["Reading the thread", "Drafting a reply"],
+    });
+
+    assert.equal(response.error, undefined);
+    const params = await body;
+    assert.equal(params.get("status"), "is thinking...");
+    // String arrays are comma-joined by the client, not JSON-encoded.
+    assert.equal(params.get("loading_messages"), "Reading the thread,Drafting a reply");
+  });
+});


### PR DESCRIPTION
Fixes #54.

Adds three request types that lag the current Slack API:

- **`chat.startStream` / `appendStream` / `stopStream`**: `chunks` (`blocks` | `markdown_text` | `plan_update` | `task_update`) + `task_display_mode`; `appendStream.markdown_text` made optional.
- **`chat.unfurl`**: `unfurls` made optional; add `metadata.entities` (work-object entity unfurls). Entity types mirror `@slack/types` `EntityMetadata`, mapped onto this package's block-kit primitives.
- **`assistant.threads.setStatus`**: optional `loading_messages`.

Tests cover wire serialization of the new fields. `src_deno` regenerated via `scripts/generate-deno-source.sh` (also picks up a prior `src`/`src_deno` `block-elements` drift).

Verified end-to-end against our live Slack API — a real app streamed `chunks` and rendered the task timeline.
