### PR TITLE
Add support for the data_visualization block

### DIFF
--- a/src/block-kit/blocks.ts
+++ b/src/block-kit/blocks.ts
@@ -46,7 +46,8 @@ export type AnyBlockType =
   | "carousel"
   | "plan"
   | "table"
-  | "task_card";
+  | "task_card"
+  | "data_visualization";
 
 export interface Block<T extends AnyBlockType = AnyBlockType> {
   type: T;
@@ -75,7 +76,8 @@ export declare type AnyMessageBlock =
   | CarouselBlock
   | PlanBlock
   | TableBlock
-  | TaskCardBlock;
+  | TaskCardBlock
+  | DataVisualizationBlock;
 
 export declare type AnyModalBlock =
   | ActionsBlock
@@ -297,4 +299,35 @@ export interface TaskCardBlock extends Block<"task_card"> {
   output?: RichTextBlock;
   sources?: UrlSource[];
   status?: "pending" | "in_progress" | "complete" | "error";
+}
+
+// https://docs.slack.dev/reference/block-kit/blocks/data-visualization-block
+export interface DataVisualizationDataPoint {
+  label: string;
+  value: number;
+}
+export interface DataVisualizationSeries {
+  name: string;
+  data: DataVisualizationDataPoint[];
+}
+export interface DataVisualizationAxisConfig {
+  categories?: string[];
+  x_label?: string;
+  y_label?: string;
+}
+// Used by line, bar, and area charts
+export interface DataVisualizationSeriesChart {
+  type: "line" | "bar" | "area";
+  series: DataVisualizationSeries[];
+  axis_config?: DataVisualizationAxisConfig;
+}
+export interface DataVisualizationPieChart {
+  type: "pie";
+  segments: DataVisualizationDataPoint[];
+}
+export type DataVisualizationChart = DataVisualizationSeriesChart | DataVisualizationPieChart;
+export interface DataVisualizationBlock extends Block<"data_visualization"> {
+  type: "data_visualization";
+  title: string;
+  chart: DataVisualizationChart;
 }

--- a/src_deno/block-kit/blocks.ts
+++ b/src_deno/block-kit/blocks.ts
@@ -46,7 +46,8 @@ export type AnyBlockType =
   | "carousel"
   | "plan"
   | "table"
-  | "task_card";
+  | "task_card"
+  | "data_visualization";
 
 export interface Block<T extends AnyBlockType = AnyBlockType> {
   type: T;
@@ -75,7 +76,8 @@ export declare type AnyMessageBlock =
   | CarouselBlock
   | PlanBlock
   | TableBlock
-  | TaskCardBlock;
+  | TaskCardBlock
+  | DataVisualizationBlock;
 
 export declare type AnyModalBlock =
   | ActionsBlock
@@ -297,4 +299,37 @@ export interface TaskCardBlock extends Block<"task_card"> {
   output?: RichTextBlock;
   sources?: UrlSource[];
   status?: "pending" | "in_progress" | "complete" | "error";
+}
+
+// https://docs.slack.dev/reference/block-kit/blocks/data-visualization-block
+export interface DataVisualizationDataPoint {
+  label: string;
+  value: number;
+}
+export interface DataVisualizationSeries {
+  name: string;
+  data: DataVisualizationDataPoint[];
+}
+export interface DataVisualizationAxisConfig {
+  categories?: string[];
+  x_label?: string;
+  y_label?: string;
+}
+// Used by line, bar, and area charts
+export interface DataVisualizationSeriesChart {
+  type: "line" | "bar" | "area";
+  series: DataVisualizationSeries[];
+  axis_config?: DataVisualizationAxisConfig;
+}
+export interface DataVisualizationPieChart {
+  type: "pie";
+  segments: DataVisualizationDataPoint[];
+}
+export type DataVisualizationChart =
+  | DataVisualizationSeriesChart
+  | DataVisualizationPieChart;
+export interface DataVisualizationBlock extends Block<"data_visualization"> {
+  type: "data_visualization";
+  title: string;
+  chart: DataVisualizationChart;
 }

--- a/test/block-kit.test.ts
+++ b/test/block-kit.test.ts
@@ -7,6 +7,7 @@ import {
   CardBlock,
   CarouselBlock,
   ContextActionsBlock,
+  DataVisualizationBlock,
   MarkdownBlock,
   MessageInputBlock,
   PlanBlock,
@@ -329,9 +330,7 @@ describe("Block Kit types", () => {
           },
         ],
       },
-      sources: [
-        { type: "url", url: "https://example.com/", text: "Reference" },
-      ],
+      sources: [{ type: "url", url: "https://example.com/", text: "Reference" }],
     };
     const messageBlocks: AnyMessageBlock[] = [block];
     assert.equal(messageBlocks.length, 1);
@@ -378,23 +377,103 @@ describe("Block Kit types", () => {
             elements: [
               {
                 type: "rich_text_section",
-                elements: [
-                  { type: "text", text: "100", style: { bold: true } },
-                ],
+                elements: [{ type: "text", text: "100", style: { bold: true } }],
               },
             ],
           },
         ],
       ],
-      column_settings: [
-        { align: "left", is_wrapped: false },
-        { align: "right" },
-      ],
+      column_settings: [{ align: "left", is_wrapped: false }, { align: "right" }],
     };
     const messageBlocks: AnyMessageBlock[] = [block];
     assert.equal(messageBlocks.length, 1);
     assert.equal(block.rows.length, 2);
     assert.equal(block.column_settings?.length, 2);
+  });
+
+  test("parse data visualization blocks", async () => {
+    const blocks: DataVisualizationBlock[] = [
+      {
+        type: "data_visualization",
+        block_id: "viz-line-multi",
+        title: "Weekly active users by platform",
+        chart: {
+          type: "line",
+          series: [
+            {
+              name: "Desktop",
+              data: [
+                { label: "Mon", value: 800 },
+                { label: "Tue", value: 920 },
+              ],
+            },
+            {
+              name: "Mobile",
+              data: [
+                { label: "Mon", value: 400 },
+                { label: "Tue", value: 530 },
+              ],
+            },
+          ],
+          axis_config: {
+            categories: ["Mon", "Tue"],
+            x_label: "Day",
+            y_label: "Users",
+          },
+        },
+      },
+      {
+        type: "data_visualization",
+        block_id: "viz-bar-negative",
+        title: "Net headcount change",
+        chart: {
+          type: "bar",
+          series: [
+            {
+              name: "Delta",
+              data: [
+                { label: "Mon", value: 4 },
+                { label: "Tue", value: -2 },
+              ],
+            },
+          ],
+          axis_config: { x_label: "Day", y_label: "People (delta)" },
+        },
+      },
+      {
+        type: "data_visualization",
+        title: "Concurrent users by platform",
+        chart: {
+          type: "area",
+          series: [
+            {
+              name: "Desktop",
+              data: [{ label: "Mon", value: 2800 }],
+            },
+          ],
+        },
+      },
+      {
+        type: "data_visualization",
+        block_id: "viz-pie-multi",
+        title: "Plan distribution by tier",
+        chart: {
+          type: "pie",
+          segments: [
+            { label: "Free", value: 4200 },
+            { label: "Pro", value: 2300 },
+            { label: "Enterprise", value: 480 },
+          ],
+        },
+      },
+    ];
+    const messageBlocks: AnyMessageBlock[] = blocks;
+    assert.equal(messageBlocks.length, 4);
+    assert.equal(blocks[0].chart.type, "line");
+    const pie = blocks[3].chart;
+    if (pie.type === "pie") {
+      assert.equal(pie.segments.length, 3);
+    }
   });
 
   test("section block supports expand", async () => {


### PR DESCRIPTION
## Summary

Slack [introduced a new `data_visualization` Block Kit block](https://docs.slack.dev/reference/block-kit/blocks/data-visualization-block) for the Messages surface that renders **line, bar, area, and pie** charts. This adds the corresponding TypeScript types so the block can be constructed with full type-checking.

## Changes

- Add `"data_visualization"` to `AnyBlockType` and `DataVisualizationBlock` to `AnyMessageBlock` (Messages-only surface, so it is not added to modal/home-tab unions).
- Model the chart as a discriminated union on `chart.type`:
  - `line` / `bar` / `area` → `series[]` (`name`, `data[]` of `{ label, value }`) + optional `axis_config` (`categories`, `x_label`, `y_label`)
  - `pie` → `segments[]` of `{ label, value }`
- Mirror the new types into the Deno source tree (`src_deno/`).
- Add type-coverage in the Block Kit test suite covering all four chart types, multiple series, negative values, and the pie/`segments` shape.

```ts
const block: DataVisualizationBlock = {
  type: "data_visualization",
  title: "Weekly active users by platform",
  chart: {
    type: "line",
    series: [
      { name: "Desktop", data: [{ label: "Mon", value: 800 }, { label: "Tue", value: 920 }] },
      { name: "Mobile", data: [{ label: "Mon", value: 400 }, { label: "Tue", value: 530 }] },
    ],
    axis_config: { categories: ["Mon", "Tue"], x_label: "Day", y_label: "Users" },
  },
};
```

## Testing

- `npx tsc --noEmit` — passes
- `npx vitest run` — 35 tests pass
- `npx knip` — clean
- Formatted with Biome (`src`/`test`); Deno tree kept in the deno-fmt style

## Notes

The block was released the same day as this change, so it is not yet indexed by search and `docs.slack.dev` is not reachable from this environment. The types are derived from the tested JSON examples in [ENG-4936](https://linear.app/tightknit/issue/ENG-4936/support-the-new-slack-data-visualization-blocks) (verified against the rendered Slack client output). `title` is modeled as required since it is present in every example and rendered for every chart; if the upstream spec marks it optional, it's a one-line change.

Resolves ENG-4936.

https://claude.ai/code/session_01LDX5haYbD36NAybHYVK1UV

---
_Generated by [Claude Code](https://claude.ai/code/session_01LDX5haYbD36NAybHYVK1UV)_