### PR TITLE
version 1.1.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slack-web-api-client",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "description": "Streamlined Slack Web API client for TypeScript",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
Patch release bumping `package.json` to `1.1.13`.

Changes since `1.1.12`:
- Add support for the new `data_visualization` Block Kit block (line/bar/area/pie charts) for the Messages surface (#57)

Once merged, publish per `RELEASING.md`:
```
git checkout main && git pull --ff-only
npm publish            # prepublishOnly runs build:clean + ci-test; prompts for OTP
git tag v1.1.13 && git push origin v1.1.13
```
Then publish a GitHub Release at `v1.1.13`.

https://claude.ai/code/session_01LDX5haYbD36NAybHYVK1UV

---
_Generated by [Claude Code](https://claude.ai/code/session_01LDX5haYbD36NAybHYVK1UV)_