### PR TITLE
Add missing Web API methods (Java SDK / changelog parity)

### DIFF
--- a/src/client/api-client.ts
+++ b/src/client/api-client.ts
@@ -264,6 +264,27 @@ import type {
   WorkflowsTriggersDeleteRequest,
   WorkflowsTriggersListRequest,
   WorkflowsTriggersUpdateRequest,
+  WorkflowsFeaturedAddRequest,
+  WorkflowsFeaturedSetRequest,
+  WorkflowsFeaturedRemoveRequest,
+  WorkflowsFeaturedListRequest,
+  AppsUserConnectionUpdateRequest,
+  AssistantSearchContextRequest,
+  AssistantSearchInfoRequest,
+  FunctionsDistributionsPermissionsSetRequest,
+  FunctionsDistributionsPermissionsListRequest,
+  FunctionsDistributionsPermissionsAddRequest,
+  FunctionsDistributionsPermissionsRemoveRequest,
+  FunctionsWorkflowsStepsListRequest,
+  CallsAddRequest,
+  CallsEndRequest,
+  CallsInfoRequest,
+  CallsUpdateRequest,
+  CallsParticipantsAddRequest,
+  CallsParticipantsRemoveRequest,
+  AdminAnalyticsGetFileRequest,
+  AdminAppsConfigLookupRequest,
+  AdminAppsConfigSetRequest,
 } from "./request";
 import type {
   AdminAppsApproveResponse,
@@ -470,6 +491,8 @@ import type {
   AdminFunctionsListResponse,
   AdminFunctionsPermissionsLookupResponse,
   AdminFunctionsPermissionsSetResponse,
+  AdminAppsConfigLookupResponse,
+  AdminAppsConfigSetResponse,
   AdminWorkflowsSearchResponse,
   AdminWorkflowsUnpublishResponse,
   AdminWorkflowsPermissionsLookupResponse,
@@ -535,6 +558,16 @@ import type {
   WorkflowsTriggersUpdateResponse,
 } from "./automation-response/index";
 import type { FilesUploadV2Response } from "./custom-response/FilesUploadV2Response";
+import type { AssistantSearchContextResponse } from "./custom-response/AssistantSearchContextResponse";
+import type { AssistantSearchInfoResponse } from "./custom-response/AssistantSearchInfoResponse";
+import type {
+  FunctionsDistributionsPermissionsSetResponse,
+  FunctionsDistributionsPermissionsListResponse,
+} from "./custom-response/FunctionsDistributionsPermissionsResponse";
+import type { FunctionsWorkflowsStepsListResponse } from "./custom-response/FunctionsWorkflowsStepsListResponse";
+import type { WorkflowsFeaturedListResponse } from "./custom-response/WorkflowsFeaturedListResponse";
+import type { CallsAddResponse, CallsInfoResponse, CallsUpdateResponse } from "./custom-response/CallsResponse";
+import type { AdminAnalyticsGetFileResponse } from "./custom-response/AdminAnalyticsGetFileResponse";
 import type { RetryHandler, RetryHandlerState } from "./retry-handler/index";
 import { RatelimitRetryHandler } from "./retry-handler/index";
 
@@ -849,6 +882,9 @@ export class SlackAPIClient {
   // --------------------------------------
 
   public readonly admin = {
+    analytics: {
+      getFile: this.#bindApiCall<AdminAnalyticsGetFileRequest, AdminAnalyticsGetFileResponse>(this, "admin.analytics.getFile"),
+    },
     apps: {
       approve: this.#bindNoArgAllowedApiCall<AdminAppsApproveRequest, AdminAppsApproveResponse>(this, "admin.apps.approve"),
       approved: {
@@ -875,6 +911,10 @@ export class SlackAPIClient {
           this,
           "admin.apps.activities.list",
         ),
+      },
+      config: {
+        lookup: this.#bindApiCall<AdminAppsConfigLookupRequest, AdminAppsConfigLookupResponse>(this, "admin.apps.config.lookup"),
+        set: this.#bindApiCall<AdminAppsConfigSetRequest, AdminAppsConfigSetResponse>(this, "admin.apps.config.set"),
       },
     },
     auth: {
@@ -1196,6 +1236,11 @@ export class SlackAPIClient {
       export: this.#bindApiCall<AppsManifestExportRequest, AppsManifestExportResponse>(this, "apps.manifest.export"),
       validate: this.#bindApiCall<AppsManifestValidateRequest, AppsManifestValidateResponse>(this, "apps.manifest.validate"),
     },
+    user: {
+      connection: {
+        update: this.#bindApiCall<AppsUserConnectionUpdateRequest, SlackAPIResponse>(this, "apps.user.connection.update"),
+      },
+    },
     uninstall: this.#bindApiCall<AppsUninstallRequest, AppsUninstallResponse>(this, "apps.uninstall"),
   };
 
@@ -1210,6 +1255,10 @@ export class SlackAPIClient {
         "assistant.threads.setSuggestedPrompts",
       ),
       setTitle: this.#bindApiCall<AssistantThreadsSetTitleRequest, AssistantThreadsSetTitleResponse>(this, "assistant.threads.setTitle"),
+    },
+    search: {
+      context: this.#bindApiCall<AssistantSearchContextRequest, AssistantSearchContextResponse>(this, "assistant.search.context"),
+      info: this.#bindNoArgAllowedApiCall<AssistantSearchInfoRequest, AssistantSearchInfoResponse>(this, "assistant.search.info"),
     },
   };
 
@@ -1230,6 +1279,17 @@ export class SlackAPIClient {
     edit: this.#bindApiCall<BookmarksEditRequest, BookmarksEditResponse>(this, "bookmarks.edit"),
     list: this.#bindApiCall<BookmarksListRequest, BookmarksListResponse>(this, "bookmarks.list"),
     remove: this.#bindApiCall<BookmarksRemoveRequest, BookmarksRemoveResponse>(this, "bookmarks.remove"),
+  };
+
+  public readonly calls = {
+    add: this.#bindApiCall<CallsAddRequest, CallsAddResponse>(this, "calls.add"),
+    end: this.#bindApiCall<CallsEndRequest, SlackAPIResponse>(this, "calls.end"),
+    info: this.#bindApiCall<CallsInfoRequest, CallsInfoResponse>(this, "calls.info"),
+    update: this.#bindApiCall<CallsUpdateRequest, CallsUpdateResponse>(this, "calls.update"),
+    participants: {
+      add: this.#bindApiCall<CallsParticipantsAddRequest, SlackAPIResponse>(this, "calls.participants.add"),
+      remove: this.#bindApiCall<CallsParticipantsRemoveRequest, SlackAPIResponse>(this, "calls.participants.remove"),
+    },
   };
 
   public readonly canvases = {
@@ -1370,6 +1430,34 @@ export class SlackAPIClient {
       "functions.completeSuccess",
     ),
     completeError: this.#bindApiCall<FunctionsCompleteErrorRequest, FunctionsCompleteErrorResponse>(this, "functions.completeError"),
+    distributions: {
+      permissions: {
+        set: this.#bindApiCall<FunctionsDistributionsPermissionsSetRequest, FunctionsDistributionsPermissionsSetResponse>(
+          this,
+          "functions.distributions.permissions.set",
+        ),
+        list: this.#bindApiCall<FunctionsDistributionsPermissionsListRequest, FunctionsDistributionsPermissionsListResponse>(
+          this,
+          "functions.distributions.permissions.list",
+        ),
+        add: this.#bindApiCall<FunctionsDistributionsPermissionsAddRequest, SlackAPIResponse>(
+          this,
+          "functions.distributions.permissions.add",
+        ),
+        remove: this.#bindApiCall<FunctionsDistributionsPermissionsRemoveRequest, SlackAPIResponse>(
+          this,
+          "functions.distributions.permissions.remove",
+        ),
+      },
+    },
+    workflows: {
+      steps: {
+        list: this.#bindApiCall<FunctionsWorkflowsStepsListRequest, FunctionsWorkflowsStepsListResponse>(
+          this,
+          "functions.workflows.steps.list",
+        ),
+      },
+    },
   };
 
   public readonly migration = {
@@ -1523,6 +1611,12 @@ export class SlackAPIClient {
       update: this.#bindApiCall<WorkflowsTriggersUpdateRequest, WorkflowsTriggersUpdateResponse>(this, "workflows.triggers.update"),
       delete: this.#bindApiCall<WorkflowsTriggersDeleteRequest, WorkflowsTriggersDeleteResponse>(this, "workflows.triggers.delete"),
       list: this.#bindNoArgAllowedApiCall<WorkflowsTriggersListRequest, WorkflowsTriggersListResponse>(this, "workflows.triggers.list"),
+    },
+    featured: {
+      add: this.#bindApiCall<WorkflowsFeaturedAddRequest, SlackAPIResponse>(this, "workflows.featured.add"),
+      set: this.#bindApiCall<WorkflowsFeaturedSetRequest, SlackAPIResponse>(this, "workflows.featured.set"),
+      remove: this.#bindApiCall<WorkflowsFeaturedRemoveRequest, SlackAPIResponse>(this, "workflows.featured.remove"),
+      list: this.#bindApiCall<WorkflowsFeaturedListRequest, WorkflowsFeaturedListResponse>(this, "workflows.featured.list"),
     },
   };
 }

--- a/src/client/custom-response/AdminAnalyticsGetFileResponse.ts
+++ b/src/client/custom-response/AdminAnalyticsGetFileResponse.ts
@@ -1,0 +1,11 @@
+// deno-lint-ignore-file ban-unused-ignore no-explicit-any no-empty-interface
+
+import type { SlackAPIResponse } from "../response";
+
+// admin.analytics.getFile returns a gzipped JSON file as the response body.
+export type AdminAnalyticsGetFileResponse = SlackAPIResponse & {
+  ok: boolean;
+  error?: string;
+  // deno-lint-ignore no-explicit-any
+  file_data?: any[];
+};

--- a/src/client/custom-response/AssistantSearchContextResponse.ts
+++ b/src/client/custom-response/AssistantSearchContextResponse.ts
@@ -1,0 +1,59 @@
+// deno-lint-ignore-file ban-unused-ignore no-explicit-any no-empty-interface
+
+import type { SlackAPIResponse } from "../response";
+
+export type AssistantSearchContextResponse = SlackAPIResponse & {
+  ok: boolean;
+  error?: string;
+  results?: AssistantSearchResults;
+  response_metadata?: {
+    next_cursor?: string;
+  };
+};
+
+export interface AssistantSearchResults {
+  messages?: AssistantSearchMessage[];
+  files?: AssistantSearchFile[];
+  channels?: AssistantSearchChannel[];
+}
+
+export interface AssistantSearchMessage {
+  author_name?: string;
+  author_user_id?: string;
+  team_id?: string;
+  channel_id?: string;
+  channel_name?: string;
+  message_ts?: string;
+  content?: string;
+  is_author_bot?: boolean;
+  permalink?: string;
+  // deno-lint-ignore no-explicit-any
+  blocks?: any[];
+  context_messages?: AssistantSearchMessage[];
+}
+
+export interface AssistantSearchFile {
+  uploader_user_id?: string;
+  author_user_id?: string;
+  author_name?: string;
+  team_id?: string;
+  file_id?: string;
+  date_created?: number;
+  date_updated?: number;
+  title?: string;
+  file_type?: string;
+  permalink?: string;
+  content?: string;
+}
+
+export interface AssistantSearchChannel {
+  team_id?: string;
+  creator_user_id?: string;
+  creator_name?: string;
+  date_created?: number;
+  date_updated?: number;
+  name?: string;
+  topic?: string;
+  purpose?: string;
+  permalink?: string;
+}

--- a/src/client/custom-response/AssistantSearchInfoResponse.ts
+++ b/src/client/custom-response/AssistantSearchInfoResponse.ts
@@ -1,0 +1,10 @@
+// deno-lint-ignore-file ban-unused-ignore no-explicit-any no-empty-interface
+
+import type { SlackAPIResponse } from "../response";
+
+export type AssistantSearchInfoResponse = SlackAPIResponse & {
+  ok: boolean;
+  error?: string;
+  // deno-lint-ignore no-explicit-any
+  capabilities?: Record<string, any>;
+};

--- a/src/client/custom-response/CallsResponse.ts
+++ b/src/client/custom-response/CallsResponse.ts
@@ -1,0 +1,33 @@
+// deno-lint-ignore-file ban-unused-ignore no-explicit-any no-empty-interface
+
+import type { SlackAPIResponse } from "../response";
+
+export interface Call {
+  id?: string;
+  date_start?: number;
+  external_unique_id?: string;
+  join_url?: string;
+  desktop_app_join_url?: string;
+  external_display_id?: string;
+  title?: string;
+  // deno-lint-ignore no-explicit-any
+  users?: any[];
+}
+
+export type CallsAddResponse = SlackAPIResponse & {
+  ok: boolean;
+  error?: string;
+  call?: Call;
+};
+
+export type CallsInfoResponse = SlackAPIResponse & {
+  ok: boolean;
+  error?: string;
+  call?: Call;
+};
+
+export type CallsUpdateResponse = SlackAPIResponse & {
+  ok: boolean;
+  error?: string;
+  call?: Call;
+};

--- a/src/client/custom-response/FunctionsDistributionsPermissionsResponse.ts
+++ b/src/client/custom-response/FunctionsDistributionsPermissionsResponse.ts
@@ -1,0 +1,24 @@
+// deno-lint-ignore-file ban-unused-ignore no-explicit-any no-empty-interface
+
+import type { SlackAPIResponse } from "../response";
+
+export interface FunctionDistributionUser {
+  user_id?: string;
+  username?: string;
+  email?: string;
+}
+
+export type FunctionsDistributionsPermissionsSetResponse = SlackAPIResponse & {
+  ok: boolean;
+  error?: string;
+  permission_type?: string;
+  users?: FunctionDistributionUser[];
+};
+
+export type FunctionsDistributionsPermissionsListResponse = SlackAPIResponse & {
+  ok: boolean;
+  error?: string;
+  permission_type?: string;
+  user_ids?: string[];
+  users?: FunctionDistributionUser[];
+};

--- a/src/client/custom-response/FunctionsWorkflowsStepsListResponse.ts
+++ b/src/client/custom-response/FunctionsWorkflowsStepsListResponse.ts
@@ -1,0 +1,20 @@
+// deno-lint-ignore-file ban-unused-ignore no-explicit-any no-empty-interface
+
+import type { SlackAPIResponse } from "../response";
+
+export interface WorkflowStepVersion {
+  title?: string;
+  workflow_id?: string;
+  step_id?: string;
+  is_deleted?: boolean;
+  workflow_version_created?: string;
+}
+
+export type FunctionsWorkflowsStepsListResponse = SlackAPIResponse & {
+  ok: boolean;
+  error?: string;
+  steps_versions?: WorkflowStepVersion[];
+  response_metadata?: {
+    next_cursor?: string;
+  };
+};

--- a/src/client/custom-response/WorkflowsFeaturedListResponse.ts
+++ b/src/client/custom-response/WorkflowsFeaturedListResponse.ts
@@ -1,0 +1,14 @@
+// deno-lint-ignore-file ban-unused-ignore no-explicit-any no-empty-interface
+
+import type { SlackAPIResponse } from "../response";
+
+export interface FeaturedWorkflowChannel {
+  channel_id?: string;
+  trigger_ids?: string[];
+}
+
+export type WorkflowsFeaturedListResponse = SlackAPIResponse & {
+  ok: boolean;
+  error?: string;
+  channels?: FeaturedWorkflowChannel[];
+};

--- a/src/client/request.ts
+++ b/src/client/request.ts
@@ -545,6 +545,14 @@ export interface AppsUninstallRequest extends SlackAPIRequest {
 }
 
 /*
+ * `apps.user.*`
+ */
+export interface AppsUserConnectionUpdateRequest extends SlackAPIRequest {
+  user_id: string;
+  status: "connected" | "disconnected";
+}
+
+/*
  * `assistant.threads.*`
  */
 
@@ -567,6 +575,31 @@ export interface AssistantThreadsSetTitleRequest extends SlackAPIRequest {
   thread_ts: string;
   title: string;
 }
+
+/*
+ * `assistant.search.*`
+ */
+export interface AssistantSearchContextRequest extends SlackAPIRequest, CursorPaginationEnabled {
+  query: string;
+  action_token?: string;
+  channel_types?: string[];
+  content_types?: string[];
+  include_bots?: boolean;
+  include_deleted_users?: boolean;
+  before?: number;
+  after?: number;
+  include_context_messages?: boolean;
+  context_channel_id?: string;
+  sort?: string;
+  sort_dir?: string;
+  include_message_blocks?: boolean;
+  highlight?: boolean;
+  term_clauses?: string[];
+  modifiers?: string;
+  include_archived_channels?: boolean;
+  disable_semantic_search?: boolean;
+}
+export type AssistantSearchInfoRequest = SlackAPIRequest;
 
 /*
  * `auth.*`
@@ -1114,6 +1147,32 @@ export interface FunctionsCompleteErrorRequest extends SlackAPIRequest {
   error: string;
   function_execution_id: string;
 }
+export interface FunctionsDistributionsPermissionsSetRequest extends SlackAPIRequest {
+  function_id?: string;
+  function_callback_id?: string;
+  function_app_id?: string;
+  permission_type: "everyone" | "app_collaborators" | "named_entities" | "system";
+  user_ids?: string[];
+  team_ids?: string[];
+  org_ids?: string[];
+}
+export interface FunctionsDistributionsPermissionsListRequest extends SlackAPIRequest {
+  function_id: string;
+}
+export interface FunctionsDistributionsPermissionsAddRequest extends SlackAPIRequest {
+  function_id: string;
+  user_ids: string[];
+}
+export interface FunctionsDistributionsPermissionsRemoveRequest extends SlackAPIRequest {
+  function_id: string;
+  user_ids: string[];
+}
+export interface FunctionsWorkflowsStepsListRequest extends SlackAPIRequest {
+  function_id: string;
+  workflow_id?: string;
+  workflow?: string;
+  workflow_app_id?: string;
+}
 
 /*
  * `migration.*`
@@ -1537,4 +1596,64 @@ export interface WorkflowsTriggersDeleteRequest extends SlackAPIRequest {
 export interface WorkflowsTriggersListRequest extends SlackAPIRequest, CursorPaginationEnabled {
   is_owner?: boolean;
   is_published?: boolean;
+}
+
+/*
+ * `workflows.featured.*`
+ */
+export interface WorkflowsFeaturedAddRequest extends SlackAPIRequest {
+  channel_id: string;
+  trigger_ids: string[];
+}
+export interface WorkflowsFeaturedSetRequest extends SlackAPIRequest {
+  channel_id: string;
+  trigger_ids: string[];
+}
+export interface WorkflowsFeaturedRemoveRequest extends SlackAPIRequest {
+  channel_id: string;
+  trigger_ids: string[];
+}
+export interface WorkflowsFeaturedListRequest extends SlackAPIRequest {
+  channel_ids: string[];
+}
+
+/*
+ * `calls.*`
+ */
+export interface CallUser {
+  slack_id?: string;
+  external_id?: string;
+  display_name?: string;
+  avatar_url?: string;
+}
+export interface CallsAddRequest extends SlackAPIRequest {
+  external_unique_id: string;
+  join_url: string;
+  created_by?: string;
+  date_start?: number;
+  desktop_app_join_url?: string;
+  external_display_id?: string;
+  title?: string;
+  users?: CallUser[];
+}
+export interface CallsEndRequest extends SlackAPIRequest {
+  id: string;
+  duration?: number;
+}
+export interface CallsInfoRequest extends SlackAPIRequest {
+  id: string;
+}
+export interface CallsUpdateRequest extends SlackAPIRequest {
+  id: string;
+  join_url?: string;
+  desktop_app_join_url?: string;
+  title?: string;
+}
+export interface CallsParticipantsAddRequest extends SlackAPIRequest {
+  id: string;
+  users: CallUser[];
+}
+export interface CallsParticipantsRemoveRequest extends SlackAPIRequest {
+  id: string;
+  users: CallUser[];
 }

--- a/src_deno/block-kit/block-elements.ts
+++ b/src_deno/block-kit/block-elements.ts
@@ -371,7 +371,8 @@ export interface FeedbackButton {
   text: PlainTextField;
   value: string;
 }
-export interface FeedbackButtons extends ActionBlockElement<"feedback_buttons"> {
+export interface FeedbackButtons
+  extends ActionBlockElement<"feedback_buttons"> {
   type: "feedback_buttons";
   positive_button: FeedbackButton;
   negative_button: FeedbackButton;
@@ -509,6 +510,7 @@ export interface RichTextSectionElementStyle {
   bold?: boolean;
   italic?: boolean;
   strike?: boolean;
+  underline?: boolean;
   highlight?: boolean;
   client_highlight?: boolean;
   unlink?: boolean;

--- a/src_deno/client/api-client.ts
+++ b/src_deno/client/api-client.ts
@@ -1,9 +1,12 @@
 import { SlackAPIConnectionError, SlackAPIError } from "../errors.ts";
 import type {
+  AdminAnalyticsGetFileRequest,
   AdminAppsActivitiesListRequest,
   AdminAppsApprovedListRequest,
   AdminAppsApproveRequest,
   AdminAppsClearResolutionRequest,
+  AdminAppsConfigLookupRequest,
+  AdminAppsConfigSetRequest,
   AdminAppsRequestsCancelRequest,
   AdminAppsRequestsListRequest,
   AdminAppsRestrictedListRequest,
@@ -107,6 +110,9 @@ import type {
   AppsManifestUpdateRequest,
   AppsManifestValidateRequest,
   AppsUninstallRequest,
+  AppsUserConnectionUpdateRequest,
+  AssistantSearchContextRequest,
+  AssistantSearchInfoRequest,
   AssistantThreadsSetStatusRequest,
   AssistantThreadsSetSuggestedPromptsRequest,
   AssistantThreadsSetTitleRequest,
@@ -118,6 +124,12 @@ import type {
   BookmarksListRequest,
   BookmarksRemoveRequest,
   BotsInfoRequest,
+  CallsAddRequest,
+  CallsEndRequest,
+  CallsInfoRequest,
+  CallsParticipantsAddRequest,
+  CallsParticipantsRemoveRequest,
+  CallsUpdateRequest,
   CanvasesAccessDeleteRequest,
   CanvasesAccessSetRequest,
   CanvasesCreateRequest,
@@ -191,6 +203,11 @@ import type {
   FileUploadV2,
   FunctionsCompleteErrorRequest,
   FunctionsCompleteSuccessRequest,
+  FunctionsDistributionsPermissionsAddRequest,
+  FunctionsDistributionsPermissionsListRequest,
+  FunctionsDistributionsPermissionsRemoveRequest,
+  FunctionsDistributionsPermissionsSetRequest,
+  FunctionsWorkflowsStepsListRequest,
   MigrationExchangeRequest,
   OAuthV2AccessRequest,
   OAuthV2ExchangeRequest,
@@ -260,6 +277,10 @@ import type {
   ViewsPublishRequest,
   ViewsPushRequest,
   ViewsUpdateRequest,
+  WorkflowsFeaturedAddRequest,
+  WorkflowsFeaturedListRequest,
+  WorkflowsFeaturedRemoveRequest,
+  WorkflowsFeaturedSetRequest,
   WorkflowsTriggersCreateRequest,
   WorkflowsTriggersDeleteRequest,
   WorkflowsTriggersListRequest,
@@ -270,6 +291,8 @@ import type {
   AdminAppsApprovedListResponse,
   AdminAppsApproveResponse,
   AdminAppsClearResolutionResponse,
+  AdminAppsConfigLookupResponse,
+  AdminAppsConfigSetResponse,
   AdminAppsRequestsCancelResponse,
   AdminAppsRequestsListResponse,
   AdminAppsRestrictedListResponse,
@@ -535,6 +558,20 @@ import type {
   WorkflowsTriggersUpdateResponse,
 } from "./automation-response/index.ts";
 import type { FilesUploadV2Response } from "./custom-response/FilesUploadV2Response.ts";
+import type { AssistantSearchContextResponse } from "./custom-response/AssistantSearchContextResponse.ts";
+import type { AssistantSearchInfoResponse } from "./custom-response/AssistantSearchInfoResponse.ts";
+import type {
+  FunctionsDistributionsPermissionsListResponse,
+  FunctionsDistributionsPermissionsSetResponse,
+} from "./custom-response/FunctionsDistributionsPermissionsResponse.ts";
+import type { FunctionsWorkflowsStepsListResponse } from "./custom-response/FunctionsWorkflowsStepsListResponse.ts";
+import type { WorkflowsFeaturedListResponse } from "./custom-response/WorkflowsFeaturedListResponse.ts";
+import type {
+  CallsAddResponse,
+  CallsInfoResponse,
+  CallsUpdateResponse,
+} from "./custom-response/CallsResponse.ts";
+import type { AdminAnalyticsGetFileResponse } from "./custom-response/AdminAnalyticsGetFileResponse.ts";
 import type { RetryHandler, RetryHandlerState } from "./retry-handler/index.ts";
 import { RatelimitRetryHandler } from "./retry-handler/index.ts";
 
@@ -924,6 +961,12 @@ export class SlackAPIClient {
   // --------------------------------------
 
   public readonly admin = {
+    analytics: {
+      getFile: this.#bindApiCall<
+        AdminAnalyticsGetFileRequest,
+        AdminAnalyticsGetFileResponse
+      >(this, "admin.analytics.getFile"),
+    },
     apps: {
       approve: this.#bindNoArgAllowedApiCall<
         AdminAppsApproveRequest,
@@ -977,6 +1020,16 @@ export class SlackAPIClient {
           this,
           "admin.apps.activities.list",
         ),
+      },
+      config: {
+        lookup: this.#bindApiCall<
+          AdminAppsConfigLookupRequest,
+          AdminAppsConfigLookupResponse
+        >(this, "admin.apps.config.lookup"),
+        set: this.#bindApiCall<
+          AdminAppsConfigSetRequest,
+          AdminAppsConfigSetResponse
+        >(this, "admin.apps.config.set"),
       },
     },
     auth: {
@@ -1580,6 +1633,14 @@ export class SlackAPIClient {
         AppsManifestValidateResponse
       >(this, "apps.manifest.validate"),
     },
+    user: {
+      connection: {
+        update: this.#bindApiCall<
+          AppsUserConnectionUpdateRequest,
+          SlackAPIResponse
+        >(this, "apps.user.connection.update"),
+      },
+    },
     uninstall: this.#bindApiCall<AppsUninstallRequest, AppsUninstallResponse>(
       this,
       "apps.uninstall",
@@ -1606,6 +1667,16 @@ export class SlackAPIClient {
         AssistantThreadsSetTitleRequest,
         AssistantThreadsSetTitleResponse
       >(this, "assistant.threads.setTitle"),
+    },
+    search: {
+      context: this.#bindApiCall<
+        AssistantSearchContextRequest,
+        AssistantSearchContextResponse
+      >(this, "assistant.search.context"),
+      info: this.#bindNoArgAllowedApiCall<
+        AssistantSearchInfoRequest,
+        AssistantSearchInfoResponse
+      >(this, "assistant.search.info"),
     },
   };
 
@@ -1650,6 +1721,35 @@ export class SlackAPIClient {
       this,
       "bookmarks.remove",
     ),
+  };
+
+  public readonly calls = {
+    add: this.#bindApiCall<CallsAddRequest, CallsAddResponse>(
+      this,
+      "calls.add",
+    ),
+    end: this.#bindApiCall<CallsEndRequest, SlackAPIResponse>(
+      this,
+      "calls.end",
+    ),
+    info: this.#bindApiCall<CallsInfoRequest, CallsInfoResponse>(
+      this,
+      "calls.info",
+    ),
+    update: this.#bindApiCall<CallsUpdateRequest, CallsUpdateResponse>(
+      this,
+      "calls.update",
+    ),
+    participants: {
+      add: this.#bindApiCall<CallsParticipantsAddRequest, SlackAPIResponse>(
+        this,
+        "calls.participants.add",
+      ),
+      remove: this.#bindApiCall<
+        CallsParticipantsRemoveRequest,
+        SlackAPIResponse
+      >(this, "calls.participants.remove"),
+    },
   };
 
   public readonly canvases = {
@@ -1988,6 +2088,49 @@ export class SlackAPIClient {
       FunctionsCompleteErrorRequest,
       FunctionsCompleteErrorResponse
     >(this, "functions.completeError"),
+    distributions: {
+      permissions: {
+        set: this.#bindApiCall<
+          FunctionsDistributionsPermissionsSetRequest,
+          FunctionsDistributionsPermissionsSetResponse
+        >(
+          this,
+          "functions.distributions.permissions.set",
+        ),
+        list: this.#bindApiCall<
+          FunctionsDistributionsPermissionsListRequest,
+          FunctionsDistributionsPermissionsListResponse
+        >(
+          this,
+          "functions.distributions.permissions.list",
+        ),
+        add: this.#bindApiCall<
+          FunctionsDistributionsPermissionsAddRequest,
+          SlackAPIResponse
+        >(
+          this,
+          "functions.distributions.permissions.add",
+        ),
+        remove: this.#bindApiCall<
+          FunctionsDistributionsPermissionsRemoveRequest,
+          SlackAPIResponse
+        >(
+          this,
+          "functions.distributions.permissions.remove",
+        ),
+      },
+    },
+    workflows: {
+      steps: {
+        list: this.#bindApiCall<
+          FunctionsWorkflowsStepsListRequest,
+          FunctionsWorkflowsStepsListResponse
+        >(
+          this,
+          "functions.workflows.steps.list",
+        ),
+      },
+    },
   };
 
   public readonly migration = {
@@ -2354,6 +2497,24 @@ export class SlackAPIClient {
         WorkflowsTriggersListRequest,
         WorkflowsTriggersListResponse
       >(this, "workflows.triggers.list"),
+    },
+    featured: {
+      add: this.#bindApiCall<WorkflowsFeaturedAddRequest, SlackAPIResponse>(
+        this,
+        "workflows.featured.add",
+      ),
+      set: this.#bindApiCall<WorkflowsFeaturedSetRequest, SlackAPIResponse>(
+        this,
+        "workflows.featured.set",
+      ),
+      remove: this.#bindApiCall<
+        WorkflowsFeaturedRemoveRequest,
+        SlackAPIResponse
+      >(this, "workflows.featured.remove"),
+      list: this.#bindApiCall<
+        WorkflowsFeaturedListRequest,
+        WorkflowsFeaturedListResponse
+      >(this, "workflows.featured.list"),
     },
   };
 }

--- a/src_deno/client/custom-response/AdminAnalyticsGetFileResponse.ts
+++ b/src_deno/client/custom-response/AdminAnalyticsGetFileResponse.ts
@@ -1,0 +1,11 @@
+// deno-lint-ignore-file ban-unused-ignore no-explicit-any no-empty-interface
+
+import type { SlackAPIResponse } from "../response.ts";
+
+// admin.analytics.getFile returns a gzipped JSON file as the response body.
+export type AdminAnalyticsGetFileResponse = SlackAPIResponse & {
+  ok: boolean;
+  error?: string;
+  // deno-lint-ignore no-explicit-any
+  file_data?: any[];
+};

--- a/src_deno/client/custom-response/AssistantSearchContextResponse.ts
+++ b/src_deno/client/custom-response/AssistantSearchContextResponse.ts
@@ -1,0 +1,59 @@
+// deno-lint-ignore-file ban-unused-ignore no-explicit-any no-empty-interface
+
+import type { SlackAPIResponse } from "../response.ts";
+
+export type AssistantSearchContextResponse = SlackAPIResponse & {
+  ok: boolean;
+  error?: string;
+  results?: AssistantSearchResults;
+  response_metadata?: {
+    next_cursor?: string;
+  };
+};
+
+export interface AssistantSearchResults {
+  messages?: AssistantSearchMessage[];
+  files?: AssistantSearchFile[];
+  channels?: AssistantSearchChannel[];
+}
+
+export interface AssistantSearchMessage {
+  author_name?: string;
+  author_user_id?: string;
+  team_id?: string;
+  channel_id?: string;
+  channel_name?: string;
+  message_ts?: string;
+  content?: string;
+  is_author_bot?: boolean;
+  permalink?: string;
+  // deno-lint-ignore no-explicit-any
+  blocks?: any[];
+  context_messages?: AssistantSearchMessage[];
+}
+
+export interface AssistantSearchFile {
+  uploader_user_id?: string;
+  author_user_id?: string;
+  author_name?: string;
+  team_id?: string;
+  file_id?: string;
+  date_created?: number;
+  date_updated?: number;
+  title?: string;
+  file_type?: string;
+  permalink?: string;
+  content?: string;
+}
+
+export interface AssistantSearchChannel {
+  team_id?: string;
+  creator_user_id?: string;
+  creator_name?: string;
+  date_created?: number;
+  date_updated?: number;
+  name?: string;
+  topic?: string;
+  purpose?: string;
+  permalink?: string;
+}

--- a/src_deno/client/custom-response/AssistantSearchInfoResponse.ts
+++ b/src_deno/client/custom-response/AssistantSearchInfoResponse.ts
@@ -1,0 +1,10 @@
+// deno-lint-ignore-file ban-unused-ignore no-explicit-any no-empty-interface
+
+import type { SlackAPIResponse } from "../response.ts";
+
+export type AssistantSearchInfoResponse = SlackAPIResponse & {
+  ok: boolean;
+  error?: string;
+  // deno-lint-ignore no-explicit-any
+  capabilities?: Record<string, any>;
+};

--- a/src_deno/client/custom-response/CallsResponse.ts
+++ b/src_deno/client/custom-response/CallsResponse.ts
@@ -1,0 +1,33 @@
+// deno-lint-ignore-file ban-unused-ignore no-explicit-any no-empty-interface
+
+import type { SlackAPIResponse } from "../response.ts";
+
+export interface Call {
+  id?: string;
+  date_start?: number;
+  external_unique_id?: string;
+  join_url?: string;
+  desktop_app_join_url?: string;
+  external_display_id?: string;
+  title?: string;
+  // deno-lint-ignore no-explicit-any
+  users?: any[];
+}
+
+export type CallsAddResponse = SlackAPIResponse & {
+  ok: boolean;
+  error?: string;
+  call?: Call;
+};
+
+export type CallsInfoResponse = SlackAPIResponse & {
+  ok: boolean;
+  error?: string;
+  call?: Call;
+};
+
+export type CallsUpdateResponse = SlackAPIResponse & {
+  ok: boolean;
+  error?: string;
+  call?: Call;
+};

--- a/src_deno/client/custom-response/FunctionsDistributionsPermissionsResponse.ts
+++ b/src_deno/client/custom-response/FunctionsDistributionsPermissionsResponse.ts
@@ -1,0 +1,24 @@
+// deno-lint-ignore-file ban-unused-ignore no-explicit-any no-empty-interface
+
+import type { SlackAPIResponse } from "../response.ts";
+
+export interface FunctionDistributionUser {
+  user_id?: string;
+  username?: string;
+  email?: string;
+}
+
+export type FunctionsDistributionsPermissionsSetResponse = SlackAPIResponse & {
+  ok: boolean;
+  error?: string;
+  permission_type?: string;
+  users?: FunctionDistributionUser[];
+};
+
+export type FunctionsDistributionsPermissionsListResponse = SlackAPIResponse & {
+  ok: boolean;
+  error?: string;
+  permission_type?: string;
+  user_ids?: string[];
+  users?: FunctionDistributionUser[];
+};

--- a/src_deno/client/custom-response/FunctionsWorkflowsStepsListResponse.ts
+++ b/src_deno/client/custom-response/FunctionsWorkflowsStepsListResponse.ts
@@ -1,0 +1,20 @@
+// deno-lint-ignore-file ban-unused-ignore no-explicit-any no-empty-interface
+
+import type { SlackAPIResponse } from "../response.ts";
+
+export interface WorkflowStepVersion {
+  title?: string;
+  workflow_id?: string;
+  step_id?: string;
+  is_deleted?: boolean;
+  workflow_version_created?: string;
+}
+
+export type FunctionsWorkflowsStepsListResponse = SlackAPIResponse & {
+  ok: boolean;
+  error?: string;
+  steps_versions?: WorkflowStepVersion[];
+  response_metadata?: {
+    next_cursor?: string;
+  };
+};

--- a/src_deno/client/custom-response/WorkflowsFeaturedListResponse.ts
+++ b/src_deno/client/custom-response/WorkflowsFeaturedListResponse.ts
@@ -1,0 +1,14 @@
+// deno-lint-ignore-file ban-unused-ignore no-explicit-any no-empty-interface
+
+import type { SlackAPIResponse } from "../response.ts";
+
+export interface FeaturedWorkflowChannel {
+  channel_id?: string;
+  trigger_ids?: string[];
+}
+
+export type WorkflowsFeaturedListResponse = SlackAPIResponse & {
+  ok: boolean;
+  error?: string;
+  channels?: FeaturedWorkflowChannel[];
+};

--- a/src_deno/client/request.ts
+++ b/src_deno/client/request.ts
@@ -590,6 +590,14 @@ export interface AppsUninstallRequest extends SlackAPIRequest {
 }
 
 /*
+ * `apps.user.*`
+ */
+export interface AppsUserConnectionUpdateRequest extends SlackAPIRequest {
+  user_id: string;
+  status: "connected" | "disconnected";
+}
+
+/*
  * `assistant.threads.*`
  */
 
@@ -613,6 +621,32 @@ export interface AssistantThreadsSetTitleRequest extends SlackAPIRequest {
   thread_ts: string;
   title: string;
 }
+
+/*
+ * `assistant.search.*`
+ */
+export interface AssistantSearchContextRequest
+  extends SlackAPIRequest, CursorPaginationEnabled {
+  query: string;
+  action_token?: string;
+  channel_types?: string[];
+  content_types?: string[];
+  include_bots?: boolean;
+  include_deleted_users?: boolean;
+  before?: number;
+  after?: number;
+  include_context_messages?: boolean;
+  context_channel_id?: string;
+  sort?: string;
+  sort_dir?: string;
+  include_message_blocks?: boolean;
+  highlight?: boolean;
+  term_clauses?: string[];
+  modifiers?: string;
+  include_archived_channels?: boolean;
+  disable_semantic_search?: boolean;
+}
+export type AssistantSearchInfoRequest = SlackAPIRequest;
 
 /*
  * `auth.*`
@@ -1189,6 +1223,40 @@ export interface FunctionsCompleteErrorRequest extends SlackAPIRequest {
   error: string;
   function_execution_id: string;
 }
+export interface FunctionsDistributionsPermissionsSetRequest
+  extends SlackAPIRequest {
+  function_id?: string;
+  function_callback_id?: string;
+  function_app_id?: string;
+  permission_type:
+    | "everyone"
+    | "app_collaborators"
+    | "named_entities"
+    | "system";
+  user_ids?: string[];
+  team_ids?: string[];
+  org_ids?: string[];
+}
+export interface FunctionsDistributionsPermissionsListRequest
+  extends SlackAPIRequest {
+  function_id: string;
+}
+export interface FunctionsDistributionsPermissionsAddRequest
+  extends SlackAPIRequest {
+  function_id: string;
+  user_ids: string[];
+}
+export interface FunctionsDistributionsPermissionsRemoveRequest
+  extends SlackAPIRequest {
+  function_id: string;
+  user_ids: string[];
+}
+export interface FunctionsWorkflowsStepsListRequest extends SlackAPIRequest {
+  function_id: string;
+  workflow_id?: string;
+  workflow?: string;
+  workflow_app_id?: string;
+}
 
 /*
  * `migration.*`
@@ -1638,4 +1706,64 @@ export interface WorkflowsTriggersListRequest
   extends SlackAPIRequest, CursorPaginationEnabled {
   is_owner?: boolean;
   is_published?: boolean;
+}
+
+/*
+ * `workflows.featured.*`
+ */
+export interface WorkflowsFeaturedAddRequest extends SlackAPIRequest {
+  channel_id: string;
+  trigger_ids: string[];
+}
+export interface WorkflowsFeaturedSetRequest extends SlackAPIRequest {
+  channel_id: string;
+  trigger_ids: string[];
+}
+export interface WorkflowsFeaturedRemoveRequest extends SlackAPIRequest {
+  channel_id: string;
+  trigger_ids: string[];
+}
+export interface WorkflowsFeaturedListRequest extends SlackAPIRequest {
+  channel_ids: string[];
+}
+
+/*
+ * `calls.*`
+ */
+export interface CallUser {
+  slack_id?: string;
+  external_id?: string;
+  display_name?: string;
+  avatar_url?: string;
+}
+export interface CallsAddRequest extends SlackAPIRequest {
+  external_unique_id: string;
+  join_url: string;
+  created_by?: string;
+  date_start?: number;
+  desktop_app_join_url?: string;
+  external_display_id?: string;
+  title?: string;
+  users?: CallUser[];
+}
+export interface CallsEndRequest extends SlackAPIRequest {
+  id: string;
+  duration?: number;
+}
+export interface CallsInfoRequest extends SlackAPIRequest {
+  id: string;
+}
+export interface CallsUpdateRequest extends SlackAPIRequest {
+  id: string;
+  join_url?: string;
+  desktop_app_join_url?: string;
+  title?: string;
+}
+export interface CallsParticipantsAddRequest extends SlackAPIRequest {
+  id: string;
+  users: CallUser[];
+}
+export interface CallsParticipantsRemoveRequest extends SlackAPIRequest {
+  id: string;
+  users: CallUser[];
 }


### PR DESCRIPTION
## Summary

Ports **21 Web API methods** that exist in the official [Java SDK](https://github.com/slackapi/java-slack-sdk) and the [Slack changelog](https://docs.slack.dev/changelog) but were missing here. Found by diffing this client's surface against the Java SDK `MethodsClient` and the changelog (slack-edge needs nothing new from this client; Block Kit & events were already at parity).

| Group | Methods |
|---|---|
| Half-ported, now wired | `admin.analytics.getFile`, `admin.apps.config.lookup`, `admin.apps.config.set` |
| AI / agents | `assistant.search.context`, `assistant.search.info` |
| Custom functions | `functions.distributions.permissions.{set,list,add,remove}`, `functions.workflows.steps.list` |
| Workflows | `workflows.featured.{add,set,remove,list}` |
| Calls | `calls.{add,end,info,update}`, `calls.participants.{add,remove}` |
| Misc | `apps.user.connection.update` |

The three `admin.*` methods already had request interfaces in `request.ts` that were never wired into `api-client.ts` (dead types) — this finishes them.

## Approach

Each method gets a request interface, a typed response (named types in `custom-response/` for payload-bearing methods, generic `SlackAPIResponse` for ok-only ones), and a `#bindApiCall` in `api-client.ts`. Parameter shapes were taken from the live Slack method docs, not guessed. `src_deno` was regenerated via `scripts/generate-deno-source.sh` (which also picked up pre-existing `underline`/formatting drift in the Deno mirror).

Method count: 259 → 280.

## Verification

- `tsc --noEmit` — clean
- `deno fmt` / `deno lint` / `deno check` — clean
- `vitest` — 35/35 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
