### PR TITLE
Add support for the container block

### DIFF
--- a/src/block-kit/blocks.ts
+++ b/src/block-kit/blocks.ts
@@ -47,7 +47,8 @@ export type AnyBlockType =
   | "plan"
   | "table"
   | "task_card"
-  | "data_visualization";
+  | "data_visualization"
+  | "container";
 
 export interface Block<T extends AnyBlockType = AnyBlockType> {
   type: T;
@@ -77,7 +78,8 @@ export declare type AnyMessageBlock =
   | PlanBlock
   | TableBlock
   | TaskCardBlock
-  | DataVisualizationBlock;
+  | DataVisualizationBlock
+  | ContainerBlock;
 
 export declare type AnyModalBlock =
   | ActionsBlock
@@ -330,4 +332,28 @@ export interface DataVisualizationBlock extends Block<"data_visualization"> {
   type: "data_visualization";
   title: string;
   chart: DataVisualizationChart;
+}
+
+// https://docs.slack.dev/reference/block-kit/blocks/container-block
+export type ContainerChildBlock =
+  | ActionsBlock
+  | ContextBlock
+  | DividerBlock
+  | FileBlock
+  | HeaderBlock
+  | ImageBlock
+  | MessageInputBlock
+  | RichTextBlock
+  | SectionBlock
+  | TableBlock
+  | VideoBlock;
+export interface ContainerBlock extends Block<"container"> {
+  type: "container";
+  title: PlainTextField;
+  child_blocks: ContainerChildBlock[];
+  subtitle?: AnyTextField;
+  icon?: ImageElement;
+  width?: "narrow" | "standard" | "wide" | "full";
+  is_collapsible?: boolean;
+  default_collapsed?: boolean;
 }

--- a/src_deno/block-kit/blocks.ts
+++ b/src_deno/block-kit/blocks.ts
@@ -47,7 +47,8 @@ export type AnyBlockType =
   | "plan"
   | "table"
   | "task_card"
-  | "data_visualization";
+  | "data_visualization"
+  | "container";
 
 export interface Block<T extends AnyBlockType = AnyBlockType> {
   type: T;
@@ -77,7 +78,8 @@ export declare type AnyMessageBlock =
   | PlanBlock
   | TableBlock
   | TaskCardBlock
-  | DataVisualizationBlock;
+  | DataVisualizationBlock
+  | ContainerBlock;
 
 export declare type AnyModalBlock =
   | ActionsBlock
@@ -332,4 +334,28 @@ export interface DataVisualizationBlock extends Block<"data_visualization"> {
   type: "data_visualization";
   title: string;
   chart: DataVisualizationChart;
+}
+
+// https://docs.slack.dev/reference/block-kit/blocks/container-block
+export type ContainerChildBlock =
+  | ActionsBlock
+  | ContextBlock
+  | DividerBlock
+  | FileBlock
+  | HeaderBlock
+  | ImageBlock
+  | MessageInputBlock
+  | RichTextBlock
+  | SectionBlock
+  | TableBlock
+  | VideoBlock;
+export interface ContainerBlock extends Block<"container"> {
+  type: "container";
+  title: PlainTextField;
+  child_blocks: ContainerChildBlock[];
+  subtitle?: AnyTextField;
+  icon?: ImageElement;
+  width?: "narrow" | "standard" | "wide" | "full";
+  is_collapsible?: boolean;
+  default_collapsed?: boolean;
 }

--- a/test/block-kit.test.ts
+++ b/test/block-kit.test.ts
@@ -6,6 +6,7 @@ import {
   AnyRichTextBlockElement,
   CardBlock,
   CarouselBlock,
+  ContainerBlock,
   ContextActionsBlock,
   DataVisualizationBlock,
   MarkdownBlock,
@@ -474,6 +475,28 @@ describe("Block Kit types", () => {
     if (pie.type === "pie") {
       assert.equal(pie.segments.length, 3);
     }
+  });
+
+  test("parse container blocks", async () => {
+    const block: ContainerBlock = {
+      type: "container",
+      block_id: "container-1",
+      title: { type: "plain_text", text: "Deployment summary" },
+      subtitle: { type: "mrkdwn", text: "*3* services updated" },
+      icon: { type: "image", image_url: "https://example.com/icon.png", alt_text: "icon" },
+      width: "wide",
+      is_collapsible: true,
+      default_collapsed: false,
+      child_blocks: [
+        { type: "header", text: { type: "plain_text", text: "Services" } },
+        { type: "divider" },
+        { type: "section", text: { type: "mrkdwn", text: "All green ✅" } },
+      ],
+    };
+    const messageBlocks: AnyMessageBlock[] = [block];
+    assert.equal(messageBlocks.length, 1);
+    assert.equal(block.width, "wide");
+    assert.equal(block.child_blocks.length, 3);
   });
 
   test("section block supports expand", async () => {


### PR DESCRIPTION
## Summary
Adds support for Slack's Block Kit [container block](https://docs.slack.dev/reference/block-kit/blocks/container-block) — a general-purpose wrapper for grouping child blocks together with a configurable width.

`ContainerBlock` fields:
- `title` (plain_text, required), `child_blocks` (required)
- `width`: `narrow` | `standard` | `wide` | `full` (the configurable size)
- optional `subtitle`, `icon`, `is_collapsible`, `default_collapsed`

Added to `AnyBlockType` and `AnyMessageBlock`, in both `src/` and `src_deno/`, with a test.

Closes ENG-5090.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
