### PR TITLE
version 1.1.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slack-web-api-client",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "description": "Streamlined Slack Web API client for TypeScript",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
Patch release bumping `1.1.13` → `1.1.14`.

Includes unreleased changes since v1.1.13:
- feat(types): streaming chunks, entity unfurls, assistant loading_messages (#55)
- Add support for the container block (#65)
- dependency bumps (#42, #59, #60, #61, #62, #63)

After merge: tag `v1.1.14` on main and `npm publish` (prepublishOnly runs build + tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
